### PR TITLE
Fix pre-commit config newline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,6 @@
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
   rev: v0.11.2
   hooks:
-    # Run the linter.
     - id: ruff
-      args: [ --fix ]
-    # Run the formatter.
+      args: [--fix]
     - id: ruff-format


### PR DESCRIPTION
## Summary
- recreate `.pre-commit-config.yaml` with the ruff configuration and a newline at EOF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68653a7a708083258121a77d222d45ee