### PR TITLE
Expose common utilities in package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `seqjax.model.ar` module contains a small autoregressive example. The snippe
 ```python
 import jax.random as jrandom
 from seqjax.model.ar import AR1Target, ARParameters
-from seqjax.model.simulate import simulate
+from seqjax import simulate
 
 # Model parameters and target
 parameters = ARParameters(

--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -1,1 +1,25 @@
 """Utilities for sequential probabilistic models built on JAX."""
+
+# Re-export frequently used modules and classes from the package root for
+# convenience.  Users can simply ``import seqjax`` and access these components
+# without needing to know the underlying module structure.
+
+# simulation and evaluation helpers
+from .model import evaluate, simulate
+
+# base model interfaces
+from .model.base import Emission, Prior, Target, Transition
+
+# simple inference utilities
+from .inference.particlefilter import BootstrapParticleFilter
+
+__all__ = [
+    "simulate",
+    "evaluate",
+    "Prior",
+    "Transition",
+    "Emission",
+    "Target",
+    "BootstrapParticleFilter",
+]
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 jax = pytest.importorskip("jax")
 import jax.numpy as jnp
 
-from seqjax.model import simulate, evaluate
+from seqjax import simulate, evaluate
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax.model.stochastic_vol import SimpleStochasticVol, LogVolRW, TimeIncrement
 

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -1,18 +1,17 @@
 import jax.random as jrandom
 
 from seqjax.model.ar import AR1Target, ARParameters
-from seqjax.model.simulate import simulate
-from seqjax.inference.particlefilter import (
-    BootstrapParticleFilter,
-    run_filter,
-)
+from seqjax import BootstrapParticleFilter, simulate
+from seqjax.inference.particlefilter import run_filter
 
 
 def test_ar1_bootstrap_filter_runs() -> None:
     key = jrandom.PRNGKey(0)
     target = AR1Target()
     parameters = ARParameters()
-    _, observations = simulate(key, target, None, parameters, sequence_length=5)
+    _, observations = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
 
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -7,7 +7,7 @@ import pytest
 from jaxtyping import PRNGKeyArray, Scalar
 import equinox as eqx
 
-from seqjax.model.base import Prior, Transition, Emission
+from seqjax import Emission, Prior, Transition
 from seqjax.model.typing import Condition, Observation, Parameters, Particle
 
 


### PR DESCRIPTION
## Summary
- re-export simulate/evaluate modules, base classes and inference utilities from package root
- update README example to use new imports
- adjust unit tests to import from `seqjax`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866465bc9fc832586b77b17c54b6cdb