### PR TITLE
Add py.typed to package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
     "pytest",
 ]
 
+[tool.hatch.build]
+include = ["seqjax/*", "seqjax/py.typed"]
+
 [tool.ruff]
 extend-exclude = ["seqjax/inference/particlefilter.py", "sketch.ipynb", "notebooks/*"]
 


### PR DESCRIPTION
## Summary
- mark library as typed by adding a `py.typed` marker file
- include the marker via Hatch build configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664682aaf48325a3afdc90e0d0a419