### PR TITLE
Add type hints to resampling functions

### DIFF
--- a/seqjax/inference/particlefilter.py
+++ b/seqjax/inference/particlefilter.py
@@ -22,7 +22,12 @@ from seqjax.util import dynamic_index_pytree_in_dim as index_tree
 Resampler = Callable[[PRNGKeyArray, Array, ParticleType, Scalar], ParticleType]
 
 
-def gumbel_resample_from_log_weights(key, log_weights, particles, ess_e):
+def gumbel_resample_from_log_weights(
+    key: PRNGKeyArray,
+    log_weights: Float[Array, "num_particles"],
+    particles: tuple[ParticleType, ...],
+    ess_e: Scalar,
+) -> tuple[ParticleType, ...]:
     # gumbel max trick
     gumbels = -jnp.log(
         -jnp.log(jrandom.uniform(key, (log_weights.shape[0], log_weights.shape[0])))
@@ -32,8 +37,13 @@ def gumbel_resample_from_log_weights(key, log_weights, particles, ess_e):
 
 
 def conditional_resample(
-    key, log_weights, particles, ess_e, resampler: Resampler, esse_threshold: float
-):
+    key: PRNGKeyArray,
+    log_weights: Float[Array, "num_particles"],
+    particles: tuple[ParticleType, ...],
+    ess_e: Scalar,
+    resampler: Resampler,
+    esse_threshold: float,
+) -> tuple[ParticleType, ...]:
     particles = jax.lax.cond(
         ess_e < esse_threshold,
         lambda p: resampler(key, log_weights, p, ess_e),


### PR DESCRIPTION
## Summary
- annotate `gumbel_resample_from_log_weights` and `conditional_resample`
  with full type hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664686a23c8325803c44268d4db5af