### PR TITLE
Add bootstrap filter experiment

### DIFF
--- a/experiments/stochastic_vol/bootstrap_filter.py
+++ b/experiments/stochastic_vol/bootstrap_filter.py
@@ -1,0 +1,65 @@
+import matplotlib.pyplot as plt
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.model import simulate
+from seqjax.model.stochastic_vol import (
+    SkewStochasticVol,
+    LogVolWithSkew,
+    TimeIncrement,
+)
+from seqjax.inference.particlefilter import BootstrapParticleFilter, run_filter
+
+
+def mean_log_vol(weights, particles):
+    current = particles[-1]
+    return jnp.sum(current.log_vol * weights)
+
+
+if __name__ == "__main__":
+    steps = 200
+    params = LogVolWithSkew(
+        std_log_vol=jnp.array(3.2),
+        mean_reversion=jnp.array(12.0),
+        long_term_vol=jnp.array(0.16),
+        skew=jnp.array(0.8),
+    )
+
+    dt = jnp.array(1.0 / (256 * 8))
+    cond = TimeIncrement(dt * jnp.ones(steps + 1))
+
+    key = jrandom.key(0)
+    latent, obs = simulate.simulate(
+        key,
+        SkewStochasticVol,
+        cond,
+        params,
+        sequence_length=steps,
+    )
+
+    bpf = BootstrapParticleFilter(SkewStochasticVol, num_particles=500)
+    filter_key = jrandom.key(1)
+    log_w, _, ess, (filt_lv,) = run_filter(
+        bpf,
+        filter_key,
+        params,
+        obs,
+        cond,
+        recorders=(mean_log_vol,),
+    )
+
+    t = jnp.arange(filt_lv.shape[0])
+    plt.figure(figsize=(10, 4))
+    plt.plot(t, latent.log_vol, label="true")
+    plt.plot(t, filt_lv, label="filtered")
+    plt.legend()
+    plt.title("Log volatility")
+    plt.tight_layout()
+    plt.show()
+
+    plt.figure(figsize=(10, 2))
+    plt.plot(t, ess)
+    plt.title("ESS")
+    plt.tight_layout()
+    plt.show()

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -16,7 +16,8 @@ def test_ar1_bootstrap_filter_runs() -> None:
 
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, particles, ess = run_filter(bpf, filter_key, parameters, observations)
+    log_w, particles, ess, rec = run_filter(bpf, filter_key, parameters, observations)
 
     assert log_w.shape == (bpf.num_particles,)
     assert ess.shape == (observations.y.shape[0],)
+    assert rec == ()


### PR DESCRIPTION
## Summary
- add example bootstrap filtering experiment for stochastic volatility
- extend `run_filter` with a recorder option and use it to compute the filtered mean path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866500df7648325a0d735c996655523