### PR TITLE
Add visualisation support for SequentialModel

### DIFF
--- a/experiments/stochastic_vol/bootstrap_filter.py
+++ b/experiments/stochastic_vol/bootstrap_filter.py
@@ -1,5 +1,4 @@
 import matplotlib.pyplot as plt
-import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "jax>=0.5.2",
     "equinox>=0.12.1",
     "jaxtyping>=0.2.38",
+    "graphviz",
 ]
 
 [project.optional-dependencies]

--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -6,12 +6,16 @@
 
 # simulation and evaluation helpers
 from .model import evaluate, simulate
+from .model.visualise import graph_model
 
 # base model interfaces
-from .model.base import Emission, Prior, Target, Transition
+from .model.base import Emission, Prior, SequentialModel, Transition
 
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter
+
+# Maintain backwards compatibility with the old ``Target`` name.
+Target = SequentialModel
 
 __all__ = [
     "simulate",
@@ -19,7 +23,9 @@ __all__ = [
     "Prior",
     "Transition",
     "Emission",
+    "SequentialModel",
     "Target",
+    "graph_model",
     "BootstrapParticleFilter",
 ]
 

--- a/seqjax/model/__init__.py
+++ b/seqjax/model/__init__.py
@@ -1,6 +1,7 @@
 """Convenience re-exports for model components."""
 
 from seqjax.model.base import SequentialModel
+from seqjax.model.visualise import graph_model
 from seqjax.model.typing import Observation, Particle
 
-__all__ = ["Observation", "Particle", "SequentialModel"]
+__all__ = ["Observation", "Particle", "SequentialModel", "graph_model"]

--- a/seqjax/model/evaluate.py
+++ b/seqjax/model/evaluate.py
@@ -10,7 +10,11 @@ from seqjax.model.base import (
     ParticleType,
     SequentialModel,
 )
-from seqjax.util import concat_pytree, index_pytree, pytree_shape, slice_pytree
+from seqjax.util import index_pytree, pytree_shape, slice_pytree
+
+# ``Target`` used to be an alias for ``SequentialModel``.  Define the
+# alias here so that older annotations continue to import correctly.
+Target = SequentialModel
 
 
 def log_prob_x(

--- a/seqjax/model/visualise.py
+++ b/seqjax/model/visualise.py
@@ -1,0 +1,82 @@
+"""Visualisation utilities for :class:`~seqjax.model.base.SequentialModel`."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from typing import Iterable
+
+from graphviz import Digraph
+
+from .base import SequentialModel
+
+
+def _legend_table(name: str, cls: type) -> str:
+    """Return an HTML table for ``cls`` fields."""
+
+    if not is_dataclass(cls):
+        return ""
+    header = f"<tr><td colspan='2'><b>{name}</b></td></tr>"
+    rows = "".join(
+        f"<tr><td>{f.name}</td><td>${f.name}$</td></tr>" for f in fields(cls)
+    )
+    return (
+        "<<table border='0' cellborder='1' cellspacing='0'>"
+        + header
+        + rows
+        + "</table>>"
+    )
+
+
+def _add_edges(g: Digraph, srcs: Iterable[str], dst: str) -> None:
+    for s in srcs:
+        g.edge(s, dst)
+
+
+def graph_model(model: SequentialModel, *, legend: bool = False) -> Digraph:
+    """Return a :class:`graphviz.Digraph` visualising ``model``."""
+
+    g = Digraph("model")
+    g.attr(rankdir="LR")
+
+    # parameter node
+    g.node("theta", label="θ", shape="square")
+
+    max_order = max(model.prior.order, model.transition.order, model.emission.order)
+    start = -max_order + 1
+
+    # latent and observation nodes around t=0 and t=1
+    for t in range(start, 2):
+        g.node(f"x{t}", label=f"x_{t}")
+    for t in range(0, 2):
+        g.node(f"y{t}", label=f"y_{t}", shape="doublecircle")
+
+    # prior edges for initial latent states
+    for t in range(start, 1):
+        g.edge("theta", f"x{t}")
+
+    # transition to x1
+    trans_sources = [f"x{1 - i}" for i in range(1, model.transition.order + 1)]
+    _add_edges(g, trans_sources, "x1")
+    g.edge("theta", "x1")
+
+    # emissions at t=0 and t=1
+    for t in range(0, 2):
+        lat_srcs = [f"x{t - i}" for i in range(model.emission.order)]
+        _add_edges(g, lat_srcs, f"y{t}")
+        obs_srcs = [f"y{t - i}" for i in range(1, model.emission.observation_dependency + 1) if t - i >= 0]
+        _add_edges(g, obs_srcs, f"y{t}")
+        g.edge("theta", f"y{t}")
+
+    if legend:
+        orig_args = model.__class__.__orig_bases__[0].__args__
+        tables = [
+            _legend_table("Particle", orig_args[0]),
+            _legend_table("Observation", orig_args[1]),
+            _legend_table("Parameters", orig_args[3]),
+        ]
+        label = "|".join(t for t in tables if t)
+        if label:
+            g.node("legend", label=label, shape="plaintext")
+
+    return g
+

--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -1,0 +1,8 @@
+import graphviz
+from seqjax.model.ar import AR1Target
+from seqjax.model.visualise import graph_model
+
+def test_graph_model_returns_digraph() -> None:
+    model = AR1Target()
+    g = graph_model(model)
+    assert isinstance(g, graphviz.Digraph)


### PR DESCRIPTION
## Summary
- provide `graph_model` helper for visualising `SequentialModel`
- expose `graph_model` from package root
- keep backwards-compatible `Target` alias
- add simple test for new utility
- include `graphviz` as a dependency

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68665868947c8325aef925686211f778