### PR TITLE
Enhance model visualisation

### DIFF
--- a/tests/test_visualise.py
+++ b/tests/test_visualise.py
@@ -2,6 +2,29 @@ import graphviz
 from seqjax.model.ar import AR1Target
 from seqjax.model.visualise import graph_model
 
+
+def test_graph_model_includes_field_nodes() -> None:
+    model = AR1Target()
+    g = graph_model(model)
+    assert "x0_x" in g.source
+    assert "y0_y" in g.source
+
+
+def test_graph_model_render_called(monkeypatch) -> None:
+    model = AR1Target()
+    called = {}
+
+    def fake_render(self, filename, cleanup=True, format="png"):
+        called["filename"] = filename
+        called["cleanup"] = cleanup
+        called["format"] = format
+        return filename
+
+    monkeypatch.setattr(graphviz.Digraph, "render", fake_render)
+    g = graph_model(model, render="out")
+    assert isinstance(g, graphviz.Digraph)
+    assert called["filename"] == "out"
+
 def test_graph_model_returns_digraph() -> None:
     model = AR1Target()
     g = graph_model(model)


### PR DESCRIPTION
## Summary
- expand `graph_model` with per-field latent/obs/condition nodes
- allow optional rendering of model graphs
- keep rows aligned using invisible edges
- test new graph visualisation features

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686661f0690c8325b5d13813ab09fadb