### PR TITLE
Add Batched typing for sequence outputs

### DIFF
--- a/seqjax/model/evaluate.py
+++ b/seqjax/model/evaluate.py
@@ -1,7 +1,7 @@
 """Model evaluation utilities for computing log probabilities."""
 
 import jax
-from jaxtyping import PyTree, Scalar
+from jaxtyping import Scalar
 
 from seqjax.model.base import (
     ConditionType,
@@ -10,6 +10,7 @@ from seqjax.model.base import (
     ParticleType,
     SequentialModel,
 )
+from seqjax.model.typing import Batched, SequenceAxis
 from seqjax.util import index_pytree, pytree_shape, slice_pytree
 
 # ``Target`` used to be an alias for ``SequentialModel``.  Define the
@@ -19,8 +20,8 @@ Target = SequentialModel
 
 def log_prob_x(
     target: Target[ParticleType, ObservationType, ConditionType, ParametersType],
-    x_path: ParticleType,
-    condition: ConditionType,
+    x_path: Batched[ParticleType, SequenceAxis],
+    condition: Batched[ConditionType, SequenceAxis],
     parameters: ParametersType,
 ) -> Scalar:
     """Slice out particle histories for vectorised evaluation
@@ -69,12 +70,16 @@ def log_prob_x(
   
 def log_prob_y_given_x(
     target: Target[ParticleType, ObservationType, ConditionType, ParametersType],
-    x_path: PyTree,
-    y_path: PyTree,
-    condition: PyTree,
+    x_path: Batched[ParticleType, SequenceAxis],
+    y_path: Batched[ObservationType, SequenceAxis],
+    condition: Batched[ConditionType, SequenceAxis],
     parameters: ParametersType,
 ) -> Scalar:
-    """Return ``log p(y | x)`` for a sequence of observations."""
+    """Return ``log p(y | x)`` for a sequence of observations.
+
+    The ``x_path`` and ``y_path`` arguments share the same leading ``Batch``
+    dimensions, matching the output of :func:`~seqjax.model.simulate.simulate`.
+    """
     x_length = pytree_shape(x_path)[0][0]
 
     x_sequence_start = target.prior.order - 1
@@ -119,12 +124,16 @@ def log_prob_y_given_x(
 
 def log_prob_joint(
     target,
-    x_path,
-    y_path,
-    condition,
+    x_path: Batched[ParticleType, SequenceAxis],
+    y_path: Batched[ObservationType, SequenceAxis],
+    condition: Batched[ConditionType, SequenceAxis],
     parameters,
 ) -> Scalar:
-    """Return ``log p(x, y)`` for a path and observations."""
+    """Return ``log p(x, y)`` for a path and observations.
+
+    The latent and observation sequences share their ``Batch`` dimensions,
+    reflecting the output of :func:`~seqjax.model.simulate.simulate`.
+    """
     return log_prob_x(
         target,
         x_path,
@@ -144,8 +153,8 @@ def get_log_prob_x_for_target(
     """Return a ``log_prob_x`` function bound to ``target``."""
 
     def _log_prob_x(
-        x_path: PyTree,
-        condition: PyTree,
+        x_path: Batched[ParticleType, SequenceAxis],
+        condition: Batched[ConditionType, SequenceAxis],
         parameters: ParametersType,
     ):
         return log_prob_x(target, x_path, condition, parameters)
@@ -159,9 +168,9 @@ def get_log_prob_joint_for_target(
     """Return a ``log_prob_joint`` function bound to ``target``."""
 
     def _log_prob_joint(
-        x_path,
-        y_path,
-        condition,
+        x_path: Batched[ParticleType, SequenceAxis],
+        y_path: Batched[ObservationType, SequenceAxis],
+        condition: Batched[ConditionType, SequenceAxis],
         parameters,
     ):
         return log_prob_joint(target, x_path, y_path, condition, parameters)

--- a/seqjax/model/simulate.py
+++ b/seqjax/model/simulate.py
@@ -14,6 +14,7 @@ from seqjax.model.base import (
     ParticleType,
     SequentialModel,
 )
+from seqjax.model.typing import Batched, SequenceAxis
 from seqjax.util import concat_pytree, index_pytree, pytree_shape, slice_pytree
 
 
@@ -79,8 +80,8 @@ def simulate(
     parameters: ParametersType,
     sequence_length: int,
 ) -> tuple[
-    PyTree,
-    PyTree,
+    Batched[ParticleType, SequenceAxis],
+    Batched[ObservationType, SequenceAxis],
     PyTree,
     PyTree,
 ]:
@@ -110,9 +111,9 @@ def simulate(
     subsequent transition step receive the correct context.
 
     Returns ``(latents, observations, latent_history, observation_history)``.
-    The first two items contain the simulated sequences of length
-    ``sequence_length``. The final two contain the latent and observation
-    histories used for the simulation.
+    ``latents`` and ``observations`` share the same leading ``Batch`` dimensions
+    while ``SequenceAxis`` corresponds to ``sequence_length``.  The final two
+    values are the latent and observation histories used for the simulation.
     """
 
     if sequence_length < 1:

--- a/seqjax/model/typing.py
+++ b/seqjax/model/typing.py
@@ -1,6 +1,7 @@
 """Runtime type checking utilities for model interfaces."""
 
 import inspect
+from typing import Generic, Protocol, TypeVar, TypeVarTuple, Unpack
 import typing
 
 import equinox as eqx
@@ -59,11 +60,27 @@ class Parameters(eqx.Module):
 class HyperParameters(eqx.Module): ...
 
 
-ParticleType = typing.TypeVar("ParticleType", bound=Particle)
-ObservationType = typing.TypeVar("ObservationType", bound=Observation)
-ConditionType = typing.TypeVar("ConditionType", bound=Condition)
-ParametersType = typing.TypeVar("ParametersType", bound=Parameters, contravariant=True)
-HyperParametersType = typing.TypeVar("HyperParametersType", bound=HyperParameters)
+ParticleType = TypeVar("ParticleType", bound=Particle)
+ObservationType = TypeVar("ObservationType", bound=Observation)
+ConditionType = TypeVar("ConditionType", bound=Condition)
+ParametersType = TypeVar("ParametersType", bound=Parameters, contravariant=True)
+HyperParametersType = TypeVar("HyperParametersType", bound=HyperParameters)
+
+# Generic helpers -----------------------------------------------------------
+
+Batch = TypeVarTuple("Batch")
+SequenceAxis = TypeVar("SequenceAxis")
+T_co = TypeVar("T_co", covariant=True)
+
+
+class Batched(Protocol, Generic[T_co, Unpack[Batch], SequenceAxis]):
+    """A :class:`~jaxtyping.PyTree` with arbitrary leading batch axes.
+
+    ``Batch`` represents the shared leading dimensions while ``SequenceAxis``
+    denotes the trailing sequence length. Multiple return values can reuse the
+    same ``Batch`` tuple to indicate they are batched together.
+    """
+
 
 
 def resolve_annotation(annotation, type_mapping, class_vars):


### PR DESCRIPTION
## Summary
- add a `Batched` generic using `TypeVarTuple`
- use `Batched` return types in `simulate`
- apply `Batched` annotations in evaluation helpers
- document shared `Batch` dimensions in docstrings
- rename `Seq` type variable to `SequenceAxis` and simplify signatures

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68666e41b24c83259d8cd8b8fed3f59e