### PR TITLE
Modularise particle filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
 include = ["seqjax/*", "seqjax/py.typed"]
 
 [tool.ruff]
-extend-exclude = ["seqjax/inference/particlefilter.py", "sketch.ipynb", "notebooks/*"]
+extend-exclude = ["sketch.ipynb", "notebooks/*"]
 
 [tool.ruff.lint]
 select = ["E", "F"]

--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -1,0 +1,20 @@
+from .base import GeneralSequentialImportanceSampler, run_filter
+from .filter_definitions import BootstrapParticleFilter
+from .resampling import (
+    Resampler,
+    gumbel_resample_from_log_weights,
+    conditional_resample,
+)
+from .metrics import compute_esse_from_log_weights
+from .recorders import current_particle_mean
+
+__all__ = [
+    "GeneralSequentialImportanceSampler",
+    "run_filter",
+    "Resampler",
+    "gumbel_resample_from_log_weights",
+    "conditional_resample",
+    "compute_esse_from_log_weights",
+    "BootstrapParticleFilter",
+    "current_particle_mean",
+]

--- a/seqjax/inference/particlefilter/filter_definitions.py
+++ b/seqjax/inference/particlefilter/filter_definitions.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from functools import partial
+
+from seqjax.model.base import (
+    ConditionType,
+    ObservationType,
+    ParametersType,
+    ParticleType,
+    SequentialModel,
+)
+
+from .base import GeneralSequentialImportanceSampler
+from .resampling import conditional_resample, gumbel_resample_from_log_weights
+
+
+class BootstrapParticleFilter(
+    GeneralSequentialImportanceSampler[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ]
+):
+    """Classical bootstrap particle filter."""
+
+    def __init__(
+        self,
+        target: SequentialModel[
+            ParticleType, ObservationType, ConditionType, ParametersType
+        ],
+        num_particles: int,
+    ) -> None:
+        super().__init__(
+            target=target,
+            proposal=target.transition,
+            resampler=partial(
+                conditional_resample,
+                resampler=gumbel_resample_from_log_weights,
+                esse_threshold=0.5,
+            ),
+            num_particles=num_particles,
+        )

--- a/seqjax/inference/particlefilter/metrics.py
+++ b/seqjax/inference/particlefilter/metrics.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Scalar
+
+
+def compute_esse_from_log_weights(log_weights: Array) -> Scalar:
+    """Return the effective sample size efficiency for ``log_weights``."""
+    log_sum_w = jax.scipy.special.logsumexp(log_weights)
+    log_sum_w2 = jax.scipy.special.logsumexp(2 * log_weights)
+    ess = jnp.exp(2 * log_sum_w - log_sum_w2)
+    return ess / log_weights.shape[0]

--- a/seqjax/inference/particlefilter/recorders.py
+++ b/seqjax/inference/particlefilter/recorders.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from seqjax.model.base import ParticleType
+
+
+def current_particle_mean(
+    extractor: Callable[[ParticleType], Array]
+) -> Callable[[Array, tuple[ParticleType, ...]], Array]:
+    """Return a recorder capturing the mean of ``extractor`` over particles."""
+
+    def _recorder(weights: Array, particles: tuple[ParticleType, ...]) -> Array:
+        current = extractor(particles[-1])
+        return jnp.sum(current * jnp.expand_dims(weights, -1), axis=0)
+
+    return _recorder

--- a/seqjax/inference/particlefilter/resampling.py
+++ b/seqjax/inference/particlefilter/resampling.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import Array, PRNGKeyArray, Scalar
+
+from seqjax.util import dynamic_index_pytree_in_dim as index_tree
+from seqjax.model.base import ParticleType
+
+Resampler = Callable[[PRNGKeyArray, Array, ParticleType, Scalar], ParticleType]
+
+
+def gumbel_resample_from_log_weights(
+    key: PRNGKeyArray,
+    log_weights: Array,
+    particles: tuple[ParticleType, ...],
+    _ess_e: Scalar,
+) -> tuple[ParticleType, ...]:
+    """Resample particles using the Gumbel-max trick."""
+    gumbels = -jnp.log(-jnp.log(jrandom.uniform(key, (log_weights.shape[0], log_weights.shape[0]))))
+    particle_ix = jnp.argmax(log_weights + gumbels, axis=1).reshape(-1)
+    return jax.vmap(index_tree, in_axes=[None, 0, None])(particles, particle_ix, 0)
+
+
+def conditional_resample(
+    key: PRNGKeyArray,
+    log_weights: Array,
+    particles: tuple[ParticleType, ...],
+    ess_e: Scalar,
+    *,
+    resampler: Resampler,
+    esse_threshold: float,
+) -> tuple[ParticleType, ...]:
+    """Resample only when the ESS efficiency falls below ``esse_threshold``."""
+    return jax.lax.cond(
+        ess_e < esse_threshold,
+        lambda p: resampler(key, log_weights, p, ess_e),
+        lambda p: p,
+        particles,
+    )
+
+

--- a/seqjax/model/evaluate.py
+++ b/seqjax/model/evaluate.py
@@ -15,7 +15,9 @@ from seqjax.util import index_pytree, pytree_shape, slice_pytree
 
 
 def log_prob_x(
-    target: Target[ParticleType, ObservationType, ConditionType, ParametersType],
+    target: SequentialModel[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ],
     x_path: Batched[ParticleType, SequenceAxis],
     condition: Batched[ConditionType, SequenceAxis],
     parameters: ParametersType,
@@ -65,7 +67,9 @@ def log_prob_x(
 
   
 def log_prob_y_given_x(
-    target: Target[ParticleType, ObservationType, ConditionType, ParametersType],
+    target: SequentialModel[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ],
     x_path: Batched[ParticleType, SequenceAxis],
     y_path: Batched[ObservationType, SequenceAxis],
     condition: Batched[ConditionType, SequenceAxis],


### PR DESCRIPTION
## Summary
- refactor particlefilter.py into a particlefilter package
- implement resampling helpers, base classes and bootstrap filter
- expose a small recorder helper
- tighten model evaluation typing
- extract ESS calculation to metrics module and rename particle recorder

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686675ed2b848325a0ba03999178f790