### PR TITLE
Enforce initial conditions in run_filter

### DIFF
--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -1,4 +1,5 @@
 import jax.random as jrandom
+import pytest
 
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax import BootstrapParticleFilter, simulate
@@ -15,8 +16,29 @@ def test_ar1_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, particles, ess, rec = run_filter(bpf, filter_key, parameters, observations)
+    log_w, particles, ess, rec = run_filter(
+        bpf,
+        filter_key,
+        parameters,
+        observations,
+        initial_conditions=(None,),
+    )
 
     assert log_w.shape == (bpf.num_particles,)
     assert ess.shape == (observations.y.shape[0],)
     assert rec == ()
+
+
+def test_run_filter_requires_initial_conditions() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+    filter_key = jrandom.PRNGKey(1)
+    bpf = BootstrapParticleFilter(target, num_particles=10)
+
+    with pytest.raises(ValueError):
+        run_filter(bpf, filter_key, parameters, observations)


### PR DESCRIPTION
## Summary
- check for missing initial conditions in `run_filter`
- update AR1 particle filter test to supply initial conditions
- add regression test for missing initial conditions

## Testing
- `ruff check seqjax/inference/particlefilter/base.py tests/test_particlefilter.py`
- `ruff format seqjax/inference/particlefilter/base.py tests/test_particlefilter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686681fab1248325896bb7c11bfa18a1