### PR TITLE
Extend proposal interface for particle filters

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -10,6 +10,7 @@ from .model.visualise import graph_model
 
 # base model interfaces
 from .model.base import Emission, Prior, SequentialModel, Transition
+from .inference.particlefilter import Proposal
 
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter
@@ -19,6 +20,7 @@ __all__ = [
     "evaluate",
     "Prior",
     "Transition",
+    "Proposal",
     "Emission",
     "SequentialModel",
     "graph_model",

--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -1,4 +1,9 @@
-from .base import GeneralSequentialImportanceSampler, run_filter
+from .base import (
+    GeneralSequentialImportanceSampler,
+    Proposal,
+    proposal_from_transition,
+    run_filter,
+)
 from .filter_definitions import BootstrapParticleFilter
 from .resampling import (
     Resampler,
@@ -10,6 +15,8 @@ from .recorders import current_particle_mean
 
 __all__ = [
     "GeneralSequentialImportanceSampler",
+    "Proposal",
+    "proposal_from_transition",
     "run_filter",
     "Resampler",
     "gumbel_resample_from_log_weights",

--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import cached_property
 from typing import Callable, Generic, Protocol
+from abc import abstractmethod
 
 import equinox as eqx
 import jax
@@ -17,7 +18,73 @@ from seqjax.model.base import (
     SequentialModel,
     Transition,
 )
-from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.model.typing import Batched, SequenceAxis, EnforceInterface
+
+
+class Proposal(
+    eqx.Module,
+    Generic[ParticleType, ObservationType, ConditionType, ParametersType],
+    EnforceInterface,
+):
+    """Proposal distribution for sequential importance sampling."""
+
+    order: eqx.AbstractClassVar[int]
+
+    @staticmethod
+    @abstractmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle_history: tuple[ParticleType, ...],
+        observation: ObservationType,
+        condition: ConditionType,
+        parameters: ParametersType,
+    ) -> ParticleType: ...
+
+    @staticmethod
+    @abstractmethod
+    def log_prob(
+        particle_history: tuple[ParticleType, ...],
+        observation: ObservationType,
+        particle: ParticleType,
+        condition: ConditionType,
+        parameters: ParametersType,
+    ) -> Scalar: ...
+
+
+class TransitionProposal(
+    eqx.Module,
+    Generic[ParticleType, ObservationType, ConditionType, ParametersType],
+):
+    """Adapter converting a ``Transition`` to a ``Proposal``."""
+
+    transition: Transition[ParticleType, ConditionType, ParametersType]
+    order: int
+
+    def sample(
+        self,
+        key: PRNGKeyArray,
+        particle_history: tuple[ParticleType, ...],
+        observation: ObservationType,
+        condition: ConditionType,
+        parameters: ParametersType,
+    ) -> ParticleType:
+        return self.transition.sample(key, particle_history, condition, parameters)
+
+    def log_prob(
+        self,
+        particle_history: tuple[ParticleType, ...],
+        observation: ObservationType,
+        particle: ParticleType,
+        condition: ConditionType,
+        parameters: ParametersType,
+    ) -> Scalar:
+        return self.transition.log_prob(particle_history, particle, condition, parameters)
+
+
+def proposal_from_transition(
+    transition: Transition[ParticleType, ConditionType, ParametersType]
+) -> TransitionProposal[ParticleType, ObservationType, ConditionType, ParametersType]:
+    return TransitionProposal(transition=transition, order=transition.order)
 
 from .resampling import Resampler
 from .metrics import compute_esse_from_log_weights
@@ -34,17 +101,21 @@ class GeneralSequentialImportanceSampler(
     """Base class implementing sequential importance sampling."""
 
     target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType]
-    proposal: Transition[ParticleType, ConditionType, ParametersType]
+    proposal: Proposal[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ]
     resampler: Resampler
     num_particles: int
 
     @cached_property
     def proposal_sample(self) -> Callable:
-        return jax.vmap(self.proposal.sample, in_axes=[0, 0, None, None])
+        return jax.vmap(self.proposal.sample, in_axes=[0, 0, None, None, None])
 
     @cached_property
     def proposal_logp(self) -> Callable:
-        return jax.vmap(self.proposal.log_prob, in_axes=[0, 0, None, None])
+        return jax.vmap(
+            self.proposal.log_prob, in_axes=[0, None, 0, None, None]
+        )
 
     @cached_property
     def transition_logp(self) -> Callable:
@@ -79,6 +150,7 @@ class GeneralSequentialImportanceSampler(
         next_particles = self.proposal_sample(
             jrandom.split(proposal_key, self.num_particles),
             proposal_history,
+            observation,
             condition,
             params,
         )
@@ -93,7 +165,9 @@ class GeneralSequentialImportanceSampler(
         inc_weight = (
             self.transition_logp(transition_history, next_particles, condition, params)
             + self.emission_logp(emission_particles, observation, condition, params)
-            - self.proposal_logp(proposal_history, next_particles, condition, params)
+            - self.proposal_logp(
+                proposal_history, observation, next_particles, condition, params
+            )
         )
         log_w = log_w + inc_weight
 

--- a/seqjax/inference/particlefilter/filter_definitions.py
+++ b/seqjax/inference/particlefilter/filter_definitions.py
@@ -10,7 +10,7 @@ from seqjax.model.base import (
     SequentialModel,
 )
 
-from .base import GeneralSequentialImportanceSampler
+from .base import GeneralSequentialImportanceSampler, proposal_from_transition
 from .resampling import conditional_resample, gumbel_resample_from_log_weights
 
 
@@ -30,7 +30,7 @@ class BootstrapParticleFilter(
     ) -> None:
         super().__init__(
             target=target,
-            proposal=target.transition,
+            proposal=proposal_from_transition(target.transition),
             resampler=partial(
                 conditional_resample,
                 resampler=gumbel_resample_from_log_weights,


### PR DESCRIPTION
## Summary
- allow sequential importance proposals to depend on the current observation
- adapt bootstrap particle filter using a `TransitionProposal` wrapper
- expose the new `Proposal` class from the package root
- move `Proposal` interface into particle filter module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668123678083258f77905e4d016106