### PR TITLE
Add quantile and variance recorders

### DIFF
--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -11,7 +11,11 @@ from .resampling import (
     conditional_resample,
 )
 from .metrics import compute_esse_from_log_weights
-from .recorders import current_particle_mean
+from .recorders import (
+    current_particle_mean,
+    current_particle_quantiles,
+    current_particle_variance,
+)
 
 __all__ = [
     "GeneralSequentialImportanceSampler",
@@ -24,4 +28,6 @@ __all__ = [
     "compute_esse_from_log_weights",
     "BootstrapParticleFilter",
     "current_particle_mean",
+    "current_particle_quantiles",
+    "current_particle_variance",
 ]

--- a/seqjax/inference/particlefilter/recorders.py
+++ b/seqjax/inference/particlefilter/recorders.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Sequence
 
 import jax.numpy as jnp
 from jaxtyping import Array
@@ -9,12 +9,60 @@ from seqjax.model.base import ParticleType
 
 
 def current_particle_mean(
-    extractor: Callable[[ParticleType], Array]
+    extractor: Callable[[ParticleType], Array],
 ) -> Callable[[Array, tuple[ParticleType, ...]], Array]:
     """Return a recorder capturing the mean of ``extractor`` over particles."""
 
     def _recorder(weights: Array, particles: tuple[ParticleType, ...]) -> Array:
         current = extractor(particles[-1])
-        return jnp.sum(current * jnp.expand_dims(weights, -1), axis=0)
+        expanded = jnp.reshape(weights, weights.shape + (1,) * (current.ndim - 1))
+        return jnp.sum(current * expanded, axis=0)
+
+    return _recorder
+
+
+def _weighted_quantiles(values: Array, weights: Array, qs: Array) -> Array:
+    """Helper computing weighted quantiles along axis ``0``."""
+    order = jnp.argsort(values, axis=0)
+    sorted_vals = jnp.take_along_axis(values, order, axis=0)
+    sorted_weights = jnp.take_along_axis(weights[:, None], order, axis=0)
+
+    cum_weights = jnp.cumsum(sorted_weights, axis=0)
+    cum_weights = cum_weights / cum_weights[-1]
+
+    def _interp(q: Array) -> Array:
+        idx = jnp.argmax(cum_weights >= q, axis=0)
+        return jnp.take_along_axis(sorted_vals, idx[None, :], axis=0)[0]
+
+    return jnp.stack([_interp(q) for q in qs])
+
+
+def current_particle_quantiles(
+    extractor: Callable[[ParticleType], Array],
+    quantiles: Sequence[float] = (0.1, 0.9),
+) -> Callable[[Array, tuple[ParticleType, ...]], Array]:
+    """Return a recorder capturing ``quantiles`` of ``extractor`` over particles."""
+
+    qs = jnp.array(quantiles)
+
+    def _recorder(weights: Array, particles: tuple[ParticleType, ...]) -> Array:
+        current = extractor(particles[-1])
+        flat = current.reshape(current.shape[0], -1)
+        q_vals = _weighted_quantiles(flat, weights, qs)
+        return q_vals.reshape((qs.shape[0],) + current.shape[1:])
+
+    return _recorder
+
+
+def current_particle_variance(
+    extractor: Callable[[ParticleType], Array],
+) -> Callable[[Array, tuple[ParticleType, ...]], Array]:
+    """Return a recorder capturing the weighted variance of ``extractor``."""
+
+    def _recorder(weights: Array, particles: tuple[ParticleType, ...]) -> Array:
+        current = extractor(particles[-1])
+        expanded = jnp.reshape(weights, weights.shape + (1,) * (current.ndim - 1))
+        mean = jnp.sum(current * expanded, axis=0)
+        return jnp.sum(expanded * (current - mean) ** 2, axis=0)
 
     return _recorder

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -3,7 +3,11 @@ import pytest
 
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax import BootstrapParticleFilter, simulate
-from seqjax.inference.particlefilter import run_filter
+from seqjax.inference.particlefilter import (
+    run_filter,
+    current_particle_quantiles,
+    current_particle_variance,
+)
 
 
 def test_ar1_bootstrap_filter_runs() -> None:
@@ -42,3 +46,31 @@ def test_run_filter_requires_initial_conditions() -> None:
 
     with pytest.raises(ValueError):
         run_filter(bpf, filter_key, parameters, observations)
+
+
+def test_particle_recorders_shapes() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+    filter_key = jrandom.PRNGKey(1)
+    bpf = BootstrapParticleFilter(target, num_particles=20)
+
+    quant_rec = current_particle_quantiles(lambda p: p.x)
+    var_rec = current_particle_variance(lambda p: p.x)
+
+    log_w, _, _, (quant_hist, var_hist) = run_filter(
+        bpf,
+        filter_key,
+        parameters,
+        observations,
+        initial_conditions=(None,),
+        recorders=(quant_rec, var_rec),
+    )
+
+    seq_len = observations.y.shape[0]
+    assert quant_hist.shape == (seq_len, 2)
+    assert var_hist.shape == (seq_len,)


### PR DESCRIPTION
## Summary
- add weighted quantile recorder for particle filters
- provide recorder for weighted variance
- export new recorders
- test recorder outputs

## Testing
- `ruff check seqjax/inference/particlefilter/recorders.py seqjax/inference/particlefilter/__init__.py tests/test_particlefilter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686698f2ed108325a179ab9a67aa3094