### PR TITLE
Refactor particle filter sampler and log-marginal tracking

### DIFF
--- a/experiments/stochastic_vol/bootstrap_filter.py
+++ b/experiments/stochastic_vol/bootstrap_filter.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     filter_key = jrandom.key(1)
     init_conds = tuple(TimeIncrement(cond.dt[i]) for i in range(2))
     cond_path = TimeIncrement(cond.dt[2:])
-    log_w, _, ess, (filt_lv,) = run_filter(
+    log_w, _, log_mp, ess, (filt_lv,) = run_filter(
         bpf,
         filter_key,
         params,

--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -1,5 +1,5 @@
 from .base import (
-    GeneralSequentialImportanceSampler,
+    SMCSampler,
     Proposal,
     proposal_from_transition,
     run_filter,
@@ -14,7 +14,7 @@ from .metrics import compute_esse_from_log_weights
 from .recorders import current_particle_mean
 
 __all__ = [
-    "GeneralSequentialImportanceSampler",
+    "SMCSampler",
     "Proposal",
     "proposal_from_transition",
     "run_filter",

--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -19,6 +19,8 @@ from seqjax.model.base import (
     Transition,
 )
 from seqjax.model.typing import Batched, SequenceAxis, EnforceInterface
+from .resampling import Resampler
+from .metrics import compute_esse_from_log_weights
 
 
 class Proposal(
@@ -78,16 +80,15 @@ class TransitionProposal(
         condition: ConditionType,
         parameters: ParametersType,
     ) -> Scalar:
-        return self.transition.log_prob(particle_history, particle, condition, parameters)
+        return self.transition.log_prob(
+            particle_history, particle, condition, parameters
+        )
 
 
 def proposal_from_transition(
-    transition: Transition[ParticleType, ConditionType, ParametersType]
+    transition: Transition[ParticleType, ConditionType, ParametersType],
 ) -> TransitionProposal[ParticleType, ObservationType, ConditionType, ParametersType]:
     return TransitionProposal(transition=transition, order=transition.order)
-
-from .resampling import Resampler
-from .metrics import compute_esse_from_log_weights
 
 
 class Recorder(Protocol):
@@ -96,16 +97,16 @@ class Recorder(Protocol):
     ) -> PyTree: ...
 
 
-class GeneralSequentialImportanceSampler(
+class SMCSampler(
     eqx.Module,
     Generic[ParticleType, ObservationType, ConditionType, ParametersType],
 ):
-    """Base class implementing sequential importance sampling."""
+    """Base class implementing sequential Monte Carlo."""
 
-    target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType]
-    proposal: Proposal[
+    target: SequentialModel[
         ParticleType, ObservationType, ConditionType, ParametersType
     ]
+    proposal: Proposal[ParticleType, ObservationType, ConditionType, ParametersType]
     resampler: Resampler
     num_particles: int
 
@@ -115,9 +116,7 @@ class GeneralSequentialImportanceSampler(
 
     @cached_property
     def proposal_logp(self) -> Callable:
-        return jax.vmap(
-            self.proposal.log_prob, in_axes=[0, None, 0, None, None]
-        )
+        return jax.vmap(self.proposal.log_prob, in_axes=[0, None, 0, None, None])
 
     @cached_property
     def transition_logp(self) -> Callable:
@@ -145,7 +144,7 @@ class GeneralSequentialImportanceSampler(
         resample_key, proposal_key = jrandom.split(step_key)
         ess_e = compute_esse_from_log_weights(log_w)
 
-        particles = self.resampler(resample_key, log_w, particles, ess_e)
+        particles, log_w = self.resampler(resample_key, log_w, particles, ess_e)
 
         proposal_history = particles[-self.proposal.order :]
         transition_history = particles[-self.target.transition.order :]
@@ -200,9 +199,7 @@ class GeneralSequentialImportanceSampler(
 
 
 def run_filter(
-    gsis: GeneralSequentialImportanceSampler[
-        ParticleType, ObservationType, ConditionType, ParametersType
-    ],
+    smc: SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType],
     key: PRNGKeyArray,
     parameters: ParametersType,
     observation_path: Batched[ObservationType, SequenceAxis],
@@ -217,14 +214,14 @@ def run_filter(
     sequence_length = jax.tree_util.tree_leaves(observation_path)[0].shape[0]
 
     if initial_conditions is None:
-        if gsis.target.prior.order > 0:
+        if smc.target.prior.order > 0:
             raise ValueError(
                 "initial_conditions must be provided when the prior has order > 0"
             )
         initial_conditions = ()
 
     if observation_history is None:
-        if gsis.target.emission.observation_dependency > 0:
+        if smc.target.emission.observation_dependency > 0:
             raise ValueError(
                 "observation_history must be provided when the emission has observation dependency > 0"
             )
@@ -232,18 +229,18 @@ def run_filter(
 
     init_key, *step_keys = jrandom.split(key, sequence_length + 1)
 
-    init_particles = jax.vmap(gsis.target.prior.sample, in_axes=[0, None, None])(
-        jrandom.split(init_key, gsis.num_particles),
+    init_particles = jax.vmap(smc.target.prior.sample, in_axes=[0, None, None])(
+        jrandom.split(init_key, smc.num_particles),
         initial_conditions,
         parameters,
     )
 
-    log_weights = jnp.zeros((gsis.num_particles,))
+    log_weights = jnp.full((smc.num_particles,), -jnp.log(smc.num_particles))
 
     def body(state, inputs):
         step_key, observation, condition = inputs
-        log_w, particles, obs_hist = state
-        log_w, particles, obs_hist, ess_e = gsis.sample_step(
+        log_w, particles, obs_hist, log_mp_prev = state
+        log_w, particles, obs_hist, ess_e = smc.sample_step(
             step_key,
             log_w,
             particles,
@@ -252,13 +249,16 @@ def run_filter(
             condition,
             parameters,
         )
+        log_sum_w = jax.scipy.special.logsumexp(log_w)
+        log_mp = log_mp_prev + log_sum_w - jnp.log(smc.num_particles)
+        log_w = log_w - log_sum_w
         weights = jax.nn.softmax(log_w)
         recorder_vals = (
             tuple(r(weights, particles) for r in recorders)
             if recorders is not None
             else ()
         )
-        return (log_w, particles, obs_hist), (ess_e, *recorder_vals)
+        return (log_w, particles, obs_hist, log_mp), (log_mp, ess_e, *recorder_vals)
 
     if condition_path is None:
         cond_seq = [None] * sequence_length
@@ -267,13 +267,14 @@ def run_filter(
 
     final_state, scan_hist = jax.lax.scan(
         body,
-        (log_weights, init_particles, observation_history),
+        (log_weights, init_particles, observation_history, jnp.array(0.0)),
         (jnp.array(step_keys), observation_path, cond_seq),
     )
 
-    log_weights, particles, _ = final_state
+    log_weights, particles, _, log_marginal_final = final_state
 
-    ess_history = scan_hist[0]
-    recorder_history = tuple(scan_hist[1:])
+    log_marginal_history = scan_hist[0]
+    ess_history = scan_hist[1]
+    recorder_history = tuple(scan_hist[2:])
 
-    return log_weights, particles, ess_history, recorder_history
+    return log_weights, particles, log_marginal_history, ess_history, recorder_history

--- a/seqjax/inference/particlefilter/filter_definitions.py
+++ b/seqjax/inference/particlefilter/filter_definitions.py
@@ -10,14 +10,12 @@ from seqjax.model.base import (
     SequentialModel,
 )
 
-from .base import GeneralSequentialImportanceSampler, proposal_from_transition
+from .base import SMCSampler, proposal_from_transition
 from .resampling import conditional_resample, gumbel_resample_from_log_weights
 
 
 class BootstrapParticleFilter(
-    GeneralSequentialImportanceSampler[
-        ParticleType, ObservationType, ConditionType, ParametersType
-    ]
+    SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType]
 ):
     """Classical bootstrap particle filter."""
 

--- a/seqjax/inference/particlefilter/resampling.py
+++ b/seqjax/inference/particlefilter/resampling.py
@@ -10,7 +10,10 @@ from jaxtyping import Array, PRNGKeyArray, Scalar
 from seqjax.util import dynamic_index_pytree_in_dim as index_tree
 from seqjax.model.base import ParticleType
 
-Resampler = Callable[[PRNGKeyArray, Array, ParticleType, Scalar], ParticleType]
+Resampler = Callable[
+    [PRNGKeyArray, Array, tuple[ParticleType, ...], Scalar],
+    tuple[tuple[ParticleType, ...], Array],
+]
 
 
 def gumbel_resample_from_log_weights(
@@ -18,11 +21,17 @@ def gumbel_resample_from_log_weights(
     log_weights: Array,
     particles: tuple[ParticleType, ...],
     _ess_e: Scalar,
-) -> tuple[ParticleType, ...]:
+) -> tuple[tuple[ParticleType, ...], Array]:
     """Resample particles using the Gumbel-max trick."""
-    gumbels = -jnp.log(-jnp.log(jrandom.uniform(key, (log_weights.shape[0], log_weights.shape[0]))))
+    gumbels = -jnp.log(
+        -jnp.log(jrandom.uniform(key, (log_weights.shape[0], log_weights.shape[0])))
+    )
     particle_ix = jnp.argmax(log_weights + gumbels, axis=1).reshape(-1)
-    return jax.vmap(index_tree, in_axes=[None, 0, None])(particles, particle_ix, 0)
+    resampled_particles = jax.vmap(index_tree, in_axes=[None, 0, None])(
+        particles, particle_ix, 0
+    )
+    new_log_weights = jnp.full_like(log_weights, -jnp.log(log_weights.shape[0]))
+    return resampled_particles, new_log_weights
 
 
 def conditional_resample(
@@ -33,13 +42,11 @@ def conditional_resample(
     *,
     resampler: Resampler,
     esse_threshold: float,
-) -> tuple[ParticleType, ...]:
+) -> tuple[tuple[ParticleType, ...], Array]:
     """Resample only when the ESS efficiency falls below ``esse_threshold``."""
     return jax.lax.cond(
         ess_e < esse_threshold,
         lambda p: resampler(key, log_weights, p, ess_e),
-        lambda p: p,
+        lambda p: (p, log_weights),
         particles,
     )
-
-

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -16,7 +16,7 @@ def test_ar1_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, particles, ess, rec = run_filter(
+    log_w, particles, log_mp, ess, rec = run_filter(
         bpf,
         filter_key,
         parameters,
@@ -25,6 +25,7 @@ def test_ar1_bootstrap_filter_runs() -> None:
     )
 
     assert log_w.shape == (bpf.num_particles,)
+    assert log_mp.shape == (observations.y.shape[0],)
     assert ess.shape == (observations.y.shape[0],)
     assert rec == ()
 


### PR DESCRIPTION
## Summary
- rename GeneralSequentialImportanceSampler to SMCSampler
- correct resampling to reset log weights
- track marginal log-probability during filtering
- adjust particle filter helpers and tests

## Testing
- `ruff check --fix seqjax/inference/particlefilter/__init__.py seqjax/inference/particlefilter/base.py seqjax/inference/particlefilter/filter_definitions.py seqjax/inference/particlefilter/resampling.py tests/test_particlefilter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686697f58fb08325b9e4889a5407f566