### PR TITLE
Add NUTS MCMC inference

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -14,6 +14,7 @@ from .inference.particlefilter import Proposal
 
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter
+from .inference.mcmc import NUTSConfig, run_nuts
 
 __all__ = [
     "simulate",
@@ -25,5 +26,7 @@ __all__ = [
     "SequentialModel",
     "graph_model",
     "BootstrapParticleFilter",
+    "NUTSConfig",
+    "run_nuts",
 ]
 

--- a/seqjax/inference/mcmc/__init__.py
+++ b/seqjax/inference/mcmc/__init__.py
@@ -1,0 +1,3 @@
+from .nuts import NUTSConfig, run_nuts
+
+__all__ = ["NUTSConfig", "run_nuts"]

--- a/seqjax/inference/mcmc/nuts.py
+++ b/seqjax/inference/mcmc/nuts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import PRNGKeyArray
+
+from seqjax.model.base import (
+    ConditionType,
+    ObservationType,
+    ParametersType,
+    ParticleType,
+    SequentialModel,
+)
+from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.model import evaluate
+
+import blackjax
+
+
+class NUTSConfig(eqx.Module):
+    """Configuration for :func:`run_nuts`."""
+
+    step_size: float = 0.1
+    num_warmup: int = 100
+    num_samples: int = 100
+    inverse_mass_matrix: Any | None = None
+
+
+def run_nuts(
+    target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType],
+    key: PRNGKeyArray,
+    parameters: ParametersType,
+    observations: Batched[ObservationType, SequenceAxis],
+    *,
+    condition: Batched[ConditionType, SequenceAxis] | None = None,
+    initial_latents: Batched[ParticleType, SequenceAxis],
+    config: NUTSConfig = NUTSConfig(),
+) -> Batched[ParticleType, SequenceAxis | int]:
+    """Sample latent paths using the NUTS algorithm from ``blackjax``."""
+
+    log_prob_joint = evaluate.get_log_prob_joint_for_target(target)
+
+    def logdensity(x):
+        return log_prob_joint(x, observations, condition, parameters)
+
+    flat, _ = jax.flatten_util.ravel_pytree(initial_latents)
+    dim = flat.shape[0]
+    inv_mass = (
+        jnp.ones(dim)
+        if config.inverse_mass_matrix is None
+        else config.inverse_mass_matrix
+    )
+
+    nuts = blackjax.nuts(logdensity, step_size=config.step_size, inverse_mass_matrix=inv_mass)
+    state = nuts.init(initial_latents)
+
+    keys = jax.random.split(key, config.num_warmup + config.num_samples)
+
+    def warmup_step(state, key):
+        state, _ = nuts.step(key, state)
+        return state, None
+
+    state, _ = jax.lax.scan(warmup_step, state, keys[: config.num_warmup])
+
+    def sample_step(state, key):
+        state, _ = nuts.step(key, state)
+        return state, state.position
+
+    _, samples = jax.lax.scan(sample_step, state, keys[config.num_warmup:])
+    return samples

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,0 +1,27 @@
+import jax.random as jrandom
+
+from seqjax.model.ar import AR1Target, ARParameters
+from seqjax.model import simulate
+from seqjax.inference.mcmc import NUTSConfig, run_nuts
+
+
+def test_run_nuts_shape() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+    latents, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+
+    config = NUTSConfig(num_warmup=5, num_samples=3, step_size=0.1)
+    sample_key = jrandom.PRNGKey(1)
+    samples = run_nuts(
+        target,
+        sample_key,
+        parameters,
+        observations,
+        initial_latents=latents,
+        config=config,
+    )
+
+    assert samples.x.shape == (config.num_samples, latents.x.shape[0])


### PR DESCRIPTION
## Summary
- implement a minimal NUTS-based MCMC sampler using blackjax
- expose `run_nuts` and `NUTSConfig`
- test that the sampler returns samples of expected shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a1979d2c8325902f91e0d6eb0556