### PR TITLE
Implement auxiliary particle filter variant

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -13,7 +13,7 @@ from .model.base import Emission, Prior, SequentialModel, Transition
 from .inference.particlefilter import Proposal
 
 # simple inference utilities
-from .inference.particlefilter import BootstrapParticleFilter
+from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
 
 __all__ = [
     "simulate",
@@ -25,5 +25,6 @@ __all__ = [
     "SequentialModel",
     "graph_model",
     "BootstrapParticleFilter",
+    "AuxiliaryParticleFilter",
 ]
 

--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -4,7 +4,7 @@ from .base import (
     proposal_from_transition,
     run_filter,
 )
-from .filter_definitions import BootstrapParticleFilter
+from .filter_definitions import BootstrapParticleFilter, AuxiliaryParticleFilter
 from .resampling import (
     Resampler,
     gumbel_resample_from_log_weights,
@@ -27,6 +27,7 @@ __all__ = [
     "conditional_resample",
     "compute_esse_from_log_weights",
     "BootstrapParticleFilter",
+    "AuxiliaryParticleFilter",
     "current_particle_mean",
     "current_particle_quantiles",
     "current_particle_variance",

--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -130,6 +130,19 @@ class GeneralSequentialImportanceSampler(
             in_axes=[0, None, None, None, None],
         )
 
+    def _resample_log_weights(
+        self,
+        log_w: Array,
+        particles: tuple[ParticleType, ...],
+        observation_history: tuple[ObservationType, ...],
+        observation: ObservationType,
+        condition: ConditionType,
+        params: ParametersType,
+    ) -> Array:
+        """Return the log-weights used for resampling."""
+
+        return log_w
+
     def sample_step(
         self,
         step_key: PRNGKeyArray,
@@ -143,9 +156,19 @@ class GeneralSequentialImportanceSampler(
         """Advance the filter by one step and maintain particle history."""
 
         resample_key, proposal_key = jrandom.split(step_key)
-        ess_e = compute_esse_from_log_weights(log_w)
 
-        particles = self.resampler(resample_key, log_w, particles, ess_e)
+        log_w_resample = self._resample_log_weights(
+            log_w,
+            particles,
+            observation_history,
+            observation,
+            condition,
+            params,
+        )
+
+        ess_e = compute_esse_from_log_weights(log_w_resample)
+
+        particles = self.resampler(resample_key, log_w_resample, particles, ess_e)
 
         proposal_history = particles[-self.proposal.order :]
         transition_history = particles[-self.target.transition.order :]

--- a/seqjax/inference/particlefilter/filter_definitions.py
+++ b/seqjax/inference/particlefilter/filter_definitions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from functools import partial
 
+from jaxtyping import Array
+
 from seqjax.model.base import (
     ConditionType,
     ObservationType,
@@ -37,4 +39,49 @@ class BootstrapParticleFilter(
                 esse_threshold=0.5,
             ),
             num_particles=num_particles,
+        )
+
+
+class AuxiliaryParticleFilter(
+    GeneralSequentialImportanceSampler[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ]
+):
+    """Bootstrap particle filter with auxiliary resampling."""
+
+    def __init__(
+        self,
+        target: SequentialModel[
+            ParticleType, ObservationType, ConditionType, ParametersType
+        ],
+        num_particles: int,
+    ) -> None:
+        super().__init__(
+            target=target,
+            proposal=proposal_from_transition(target.transition),
+            resampler=partial(
+                conditional_resample,
+                resampler=gumbel_resample_from_log_weights,
+                esse_threshold=0.5,
+            ),
+            num_particles=num_particles,
+        )
+
+    def _resample_log_weights(
+        self,
+        log_w: Array,
+        particles: tuple[ParticleType, ...],
+        observation_history: tuple[ObservationType, ...],
+        observation: ObservationType,
+        condition: ConditionType,
+        params: ParametersType,
+    ) -> Array:
+        obs_hist = (
+            observation_history[-self.target.emission.observation_dependency :]
+            if self.target.emission.observation_dependency > 0
+            else ()
+        )
+        resample_particles = particles[-self.target.emission.order :]
+        return log_w + self.emission_logp(
+            resample_particles, obs_hist, observation, condition, params
         )

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -2,7 +2,7 @@ import jax.random as jrandom
 import pytest
 
 from seqjax.model.ar import AR1Target, ARParameters
-from seqjax import BootstrapParticleFilter, simulate
+from seqjax import BootstrapParticleFilter, AuxiliaryParticleFilter, simulate
 from seqjax.inference.particlefilter import (
     run_filter,
     current_particle_quantiles,
@@ -74,3 +74,25 @@ def test_particle_recorders_shapes() -> None:
     seq_len = observations.y.shape[0]
     assert quant_hist.shape == (seq_len, 2)
     assert var_hist.shape == (seq_len,)
+
+
+def test_ar1_auxiliary_filter_runs() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+    filter_key = jrandom.PRNGKey(1)
+    apf = AuxiliaryParticleFilter(target, num_particles=10)
+    log_w, particles, ess, _ = run_filter(
+        apf,
+        filter_key,
+        parameters,
+        observations,
+        initial_conditions=(None,),
+    )
+
+    assert log_w.shape == (apf.num_particles,)
+    assert ess.shape == (observations.y.shape[0],)


### PR DESCRIPTION
## Summary
- add `AuxiliaryParticleFilter` implementing auxiliary resampling
- export the new filter in package init files
- test that the auxiliary particle filter runs on AR1 model
- refactor `sample_step` to support auxiliary resampling in the base class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866a1499c6083259b326a587a1ded5f