### PR TITLE
Fix auxiliary filter base class and add filter tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "equinox>=0.12.1",
     "jaxtyping>=0.2.38",
     "graphviz",
+    "blackjax",
 ]
 
 [project.optional-dependencies]

--- a/seqjax/inference/particlefilter/filter_definitions.py
+++ b/seqjax/inference/particlefilter/filter_definitions.py
@@ -41,9 +41,7 @@ class BootstrapParticleFilter(
 
 
 class AuxiliaryParticleFilter(
-    GeneralSequentialImportanceSampler[
-        ParticleType, ObservationType, ConditionType, ParametersType
-    ]
+    SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType]
 ):
     """Bootstrap particle filter with auxiliary resampling."""
 

--- a/tests/test_filters_integration.py
+++ b/tests/test_filters_integration.py
@@ -1,0 +1,60 @@
+import jax.random as jrandom
+import jax.numpy as jnp
+import pytest
+
+from seqjax import BootstrapParticleFilter, AuxiliaryParticleFilter, simulate
+from seqjax.inference.particlefilter import run_filter
+from seqjax.model.ar import AR1Target, ARParameters
+from seqjax.model.stochastic_vol import (
+    SimpleStochasticVol,
+    LogVolRW,
+    TimeIncrement,
+    Underlying,
+)
+
+
+@pytest.mark.parametrize("filter_cls", [BootstrapParticleFilter, AuxiliaryParticleFilter])
+def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
+    seq_len = 5
+
+    # AR(1) model
+    key = jrandom.PRNGKey(0)
+    ar_target = AR1Target()
+    ar_params = ARParameters()
+    _, ar_obs, _, _ = simulate.simulate(key, ar_target, None, ar_params, sequence_length=seq_len)
+    filter_key = jrandom.PRNGKey(1)
+    ar_pf = filter_cls(ar_target, num_particles=5)
+    log_w, _, _, _, _ = run_filter(
+        ar_pf,
+        filter_key,
+        ar_params,
+        ar_obs,
+        initial_conditions=(None,),
+    )
+    assert log_w.shape == (ar_pf.num_particles,)
+
+    # Stochastic volatility model
+    key = jrandom.PRNGKey(2)
+    sv_target = SimpleStochasticVol()
+    sv_params = LogVolRW(
+        std_log_vol=jnp.array(0.1),
+        mean_reversion=jnp.array(0.1),
+        long_term_vol=jnp.array(1.0),
+    )
+    full_cond = TimeIncrement(jnp.ones(seq_len + sv_target.prior.order - 1))
+    _, sv_obs, _, y_hist = simulate.simulate(
+        key, sv_target, full_cond, sv_params, sequence_length=seq_len
+    )
+    sv_pf = filter_cls(sv_target, num_particles=5)
+    log_w, _, _, _, _ = run_filter(
+        sv_pf,
+        jrandom.PRNGKey(3),
+        sv_params,
+        sv_obs,
+        condition_path=TimeIncrement(full_cond.dt[sv_target.prior.order - 1 :]),
+        initial_conditions=tuple(
+            TimeIncrement(full_cond.dt[i]) for i in range(sv_target.prior.order)
+        ),
+        observation_history=(Underlying(y_hist.underlying[0]),)
+    )
+    assert log_w.shape == (sv_pf.num_particles,)

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -87,7 +87,7 @@ def test_ar1_auxiliary_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     apf = AuxiliaryParticleFilter(target, num_particles=10)
-    log_w, particles, ess, _ = run_filter(
+    log_w, particles, log_mp, ess, _ = run_filter(
         apf,
         filter_key,
         parameters,


### PR DESCRIPTION
## Summary
- fix auxiliary particle filter to subclass `SMCSampler`
- add blackjax as a required dependency
- create integration tests that run the available filters on both example models
- adjust auxiliary filter unit test for new return values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a9cc2a0c83259723a9ade35e5d52