### PR TITLE
Fix dynamic_slice_pytree implementation and tests

### DIFF
--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -75,7 +75,7 @@ def dynamic_slice_pytree(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
-            limit_index=limit_index,
+            slice_size=limit_index - start_index,
             axis=dim,
         ),
         tree,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,10 @@
 """Tests for :mod:`seqjax.util`."""
 
+import jax
 import jax.numpy as jnp
+from functools import partial
 
-from seqjax.util import pytree_shape
+from seqjax.util import dynamic_slice_pytree, pytree_shape
 
 
 def test_pytree_shape_dict() -> None:
@@ -12,3 +14,26 @@ def test_pytree_shape_dict() -> None:
     shape, leaf_count = pytree_shape(tree)
     assert shape == (2, 3)
     assert leaf_count == 2
+
+
+def test_dynamic_slice_pytree_matches_lax() -> None:
+    """``dynamic_slice_pytree`` should match ``jax.lax.dynamic_slice_in_dim``."""
+
+    tree = {"a": jnp.arange(10), "b": jnp.arange(10) * 2}
+    start_index = 2
+    limit_index = 7
+
+    sliced = dynamic_slice_pytree(tree, start_index, limit_index)
+    expected = jax.tree_util.tree_map(
+        partial(
+            jax.lax.dynamic_slice_in_dim,
+            start_index=start_index,
+            slice_size=limit_index - start_index,
+            axis=0,
+        ),
+        tree,
+    )
+
+    assert jax.tree_util.tree_all(  # type: ignore[call-arg]
+        jax.tree_util.tree_map(lambda x, y: jnp.array_equal(x, y), sliced, expected)
+    )


### PR DESCRIPTION
## Summary
- fix `dynamic_slice_pytree` to compute slice_size
- add regression test verifying behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c29141cc8325a3074ebbbcc45352