### PR TITLE
Add particle MCMC sampler

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -15,6 +15,7 @@ from .inference.particlefilter import Proposal
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
 from .inference.mcmc import NUTSConfig, run_nuts
+from .inference.pmcmc import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
 
 __all__ = [
     "simulate",
@@ -29,5 +30,8 @@ __all__ = [
     "AuxiliaryParticleFilter",
     "NUTSConfig",
     "run_nuts",
+    "RandomWalkConfig",
+    "ParticleMCMCConfig",
+    "run_particle_mcmc",
 ]
 

--- a/seqjax/inference/pmcmc/__init__.py
+++ b/seqjax/inference/pmcmc/__init__.py
@@ -1,0 +1,3 @@
+from .pmmh import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
+
+__all__ = ["RandomWalkConfig", "ParticleMCMCConfig", "run_particle_mcmc"]

--- a/seqjax/inference/pmcmc/pmmh.py
+++ b/seqjax/inference/pmcmc/pmmh.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import TypeVar
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.model.base import (
+    ConditionType,
+    ObservationType,
+    ParametersType,
+    ParticleType,
+    ParameterPrior,
+    SequentialModel,
+)
+from seqjax.model.typing import Batched, SequenceAxis, HyperParametersType
+from seqjax.inference.particlefilter import SMCSampler, run_filter
+
+
+class RandomWalkConfig(eqx.Module):
+    """Configuration for the random walk proposal used in PMCMC."""
+
+    step_size: float = 0.1
+    num_samples: int = 100
+
+
+class ParticleMCMCConfig(eqx.Module):
+    """Configuration for :func:`run_particle_mcmc`."""
+
+    mcmc: RandomWalkConfig
+    particle_filter: SMCSampler[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ]
+
+
+Parameters = TypeVar("Parameters", bound=ParametersType)
+
+
+def _propose_parameters(
+    key: jrandom.PRNGKey,
+    params: Parameters,
+    step_size: float,
+) -> Parameters:
+    flat, unravel = jax.flatten_util.ravel_pytree(params)
+    noise = step_size * jrandom.normal(key, flat.shape)
+    return unravel(flat + noise)
+
+
+def _log_density(
+    params: Parameters,
+    key: jrandom.PRNGKey,
+    pf: SMCSampler[ParticleType, ObservationType, ConditionType, Parameters],
+    prior: ParameterPrior[Parameters, HyperParametersType],
+    hyper_params: HyperParametersType | None,
+    observations: Batched[ObservationType, SequenceAxis],
+    condition_path: Batched[ConditionType, SequenceAxis] | None,
+    initial_conditions: tuple[ConditionType, ...] | None,
+    observation_history: tuple[ObservationType, ...] | None,
+) -> jnp.ndarray:
+    _, _, log_mp, _, _ = run_filter(
+        pf,
+        key,
+        params,
+        observations,
+        condition_path=condition_path,
+        initial_conditions=initial_conditions,
+        observation_history=observation_history,
+    )
+    log_like = log_mp[-1]
+    log_prior = prior.log_prob(params, hyper_params)
+    return log_like + log_prior
+
+
+def run_particle_mcmc(
+    target: SequentialModel[ParticleType, ObservationType, ConditionType, Parameters],
+    key: jrandom.PRNGKey,
+    parameter_prior: ParameterPrior[Parameters, HyperParametersType],
+    observations: Batched[ObservationType, SequenceAxis],
+    *,
+    config: ParticleMCMCConfig,
+    hyper_parameters: HyperParametersType | None = None,
+    initial_parameters: Parameters,
+    condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+    initial_conditions: tuple[ConditionType, ...] | None = None,
+    observation_history: tuple[ObservationType, ...] | None = None,
+) -> Batched[Parameters, SequenceAxis | int]:
+    """Sample parameters using particle marginal Metropolis-Hastings."""
+
+    pf = config.particle_filter
+    mcmc_cfg = config.mcmc
+
+    init_key, *step_keys = jrandom.split(key, mcmc_cfg.num_samples + 1)
+    init_logp = _log_density(
+        initial_parameters,
+        init_key,
+        pf,
+        parameter_prior,
+        hyper_parameters,
+        observations,
+        condition_path,
+        initial_conditions,
+        observation_history,
+    )
+
+    def step(state, rng):
+        params, logp = state
+        prop_key, pf_key, accept_key = jrandom.split(rng, 3)
+        proposal = _propose_parameters(prop_key, params, mcmc_cfg.step_size)
+        proposal_logp = _log_density(
+            proposal,
+            pf_key,
+            pf,
+            parameter_prior,
+            hyper_parameters,
+            observations,
+            condition_path,
+            initial_conditions,
+            observation_history,
+        )
+        log_accept_ratio = proposal_logp - logp
+        accept = jrandom.uniform(accept_key) < jnp.exp(log_accept_ratio)
+        new_params = jax.tree_util.tree_map(
+            lambda p, q: jnp.where(accept, q, p), params, proposal
+        )
+        new_logp = jnp.where(accept, proposal_logp, logp)
+        return (new_params, new_logp), new_params
+
+    _, samples = jax.lax.scan(
+        step, (initial_parameters, init_logp), jnp.array(step_keys)
+    )
+    return samples

--- a/tests/test_pmcmc.py
+++ b/tests/test_pmcmc.py
@@ -1,0 +1,33 @@
+import jax.random as jrandom
+
+from seqjax.inference.pmcmc import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
+from seqjax.inference.particlefilter import BootstrapParticleFilter
+from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax import simulate
+
+
+def test_run_particle_mcmc_shape() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+
+    pf = BootstrapParticleFilter(target, num_particles=5)
+    config = ParticleMCMCConfig(
+        mcmc=RandomWalkConfig(step_size=0.1, num_samples=3),
+        particle_filter=pf,
+    )
+    sample_key = jrandom.PRNGKey(1)
+    samples = run_particle_mcmc(
+        target,
+        sample_key,
+        HalfCauchyStds(),
+        observations,
+        config=config,
+        initial_parameters=parameters,
+        initial_conditions=(None,),
+    )
+
+    assert samples.ar.shape == (config.mcmc.num_samples,)


### PR DESCRIPTION
## Summary
- implement a simple particle marginal MCMC sampler
- expose API via new `pmcmc` submodule
- add unit test verifying output shape

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c3b7b25083259da1bfc111ae8b3d