### PR TITLE
Fix vmapped_run_filter keyword handling

### DIFF
--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -324,16 +324,25 @@ def vmapped_run_filter(
     """Vectorise :func:`run_filter` over a leading batch dimension."""
 
     cond_axes = 0 if condition_path is not None else None
-    run_vmap = jax.vmap(run_filter, in_axes=(None, 0, 0, 0, cond_axes))
+
+    def _run(key, params, obs, cond):
+        return run_filter(
+            smc,
+            key,
+            params,
+            obs,
+            cond,
+            initial_conditions=initial_conditions,
+            observation_history=observation_history,
+            recorders=recorders,
+        )
+
+    run_vmap = jax.vmap(_run, in_axes=(0, 0, 0, cond_axes))
 
     return run_vmap(
-        smc,
         key,
         parameters,
         observation_path,
         condition_path,
-        initial_conditions=initial_conditions,
-        observation_history=observation_history,
-        recorders=recorders,
     )
 


### PR DESCRIPTION
## Summary
- fix vmapped_run_filter so keyword arguments are not mapped across batch axes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c9adb92483258bdf8a1bf2750649