### PR TITLE
Add discrete HMM model and tests

### DIFF
--- a/seqjax/model/hmm.py
+++ b/seqjax/model/hmm.py
@@ -1,0 +1,126 @@
+"""Discrete Hidden Markov Model components."""
+
+from dataclasses import field
+from typing import ClassVar
+
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import Array, PRNGKeyArray, Scalar
+
+from .base import Emission, Prior, SequentialModel, Transition
+from .typing import Condition, Observation, Parameters, Particle
+
+
+class HiddenState(Particle):
+    """Latent state index for a discrete HMM."""
+
+    z: Array
+
+
+class DiscreteObservation(Observation):
+    """Discrete observation index."""
+
+    y: Array
+
+
+class HMMParameters(Parameters):
+    """Parameters of a discrete HMM."""
+
+    initial_probs: Array = field(default_factory=lambda: jnp.ones(1))
+    transition_matrix: Array = field(default_factory=lambda: jnp.ones((1, 1)))
+    emission_probs: Array = field(default_factory=lambda: jnp.ones((1, 1)))
+
+
+class CategoricalPrior(Prior[HiddenState, Condition, HMMParameters]):
+    """Prior over the initial hidden state."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        conditions: tuple[Condition],
+        parameters: HMMParameters,
+    ) -> tuple[HiddenState]:
+        state = jrandom.categorical(key, jnp.log(parameters.initial_probs))
+        return (HiddenState(z=state),)
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[HiddenState],
+        conditions: tuple[Condition],
+        parameters: HMMParameters,
+    ) -> Scalar:
+        return jnp.log(parameters.initial_probs[particle[0].z])
+
+
+class CategoricalTransition(Transition[HiddenState, Condition, HMMParameters]):
+    """Categorical state transition."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle_history: tuple[HiddenState],
+        condition: Condition,
+        parameters: HMMParameters,
+    ) -> HiddenState:
+        prev_state = particle_history[0].z
+        logits = jnp.log(parameters.transition_matrix[prev_state])
+        next_state = jrandom.categorical(key, logits)
+        return HiddenState(z=next_state)
+
+    @staticmethod
+    def log_prob(
+        particle_history: tuple[HiddenState],
+        particle: HiddenState,
+        condition: Condition,
+        parameters: HMMParameters,
+    ) -> Scalar:
+        prev_state = particle_history[0].z
+        return jnp.log(parameters.transition_matrix[prev_state, particle.z])
+
+
+class CategoricalEmission(
+    Emission[HiddenState, DiscreteObservation, Condition, HMMParameters]
+):
+    """Emission distribution conditioned on the hidden state."""
+
+    order: ClassVar[int] = 1
+    observation_dependency: ClassVar[int] = 0
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle: tuple[HiddenState],
+        observation_history: tuple[()],
+        condition: Condition,
+        parameters: HMMParameters,
+    ) -> DiscreteObservation:
+        state = particle[0].z
+        logits = jnp.log(parameters.emission_probs[state])
+        obs = jrandom.categorical(key, logits)
+        return DiscreteObservation(y=obs)
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[HiddenState],
+        observation_history: tuple[()],
+        observation: DiscreteObservation,
+        condition: Condition,
+        parameters: HMMParameters,
+    ) -> Scalar:
+        state = particle[0].z
+        return jnp.log(parameters.emission_probs[state, observation.y])
+
+
+class HiddenMarkovModel(
+    SequentialModel[HiddenState, DiscreteObservation, Condition, HMMParameters]
+):
+    """Discrete Hidden Markov Model."""
+
+    particle_type = HiddenState
+    prior = CategoricalPrior()
+    transition = CategoricalTransition()
+    emission = CategoricalEmission()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from seqjax import simulate, evaluate
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax.model.linear_gaussian import LinearGaussianSSM, LGSSMParameters
 from seqjax.model.stochastic_vol import SimpleStochasticVol, LogVolRW, TimeIncrement
+from seqjax.model.hmm import HiddenMarkovModel, HMMParameters
 from seqjax.model.base import Prior, Transition, Emission, SequentialModel
 from seqjax.util import pytree_shape
 from tests.test_typing import (
@@ -65,6 +66,23 @@ def test_simple_stochastic_vol_simulate_length() -> None:
     assert obs.underlying.shape == (3,)
     assert pytree_shape(x_hist)[0][0] == 1
     assert pytree_shape(y_hist)[0][0] == 1
+
+
+def test_hmm_simulate_length() -> None:
+    key = jax.random.PRNGKey(0)
+    params = HMMParameters(
+        initial_probs=jnp.array([0.6, 0.4]),
+        transition_matrix=jnp.array([[0.7, 0.3], [0.2, 0.8]]),
+        emission_probs=jnp.array([[0.9, 0.1], [0.2, 0.8]]),
+    )
+    latent, obs, x_hist, y_hist = simulate.simulate(
+        key, HiddenMarkovModel, None, params, sequence_length=3
+    )
+
+    assert latent.z.shape == (3,)
+    assert obs.y.shape == (3,)
+    logp = evaluate.log_prob_joint(HiddenMarkovModel, latent, obs, None, params)
+    assert jnp.shape(logp) == ()
 
 
 class Prior1(Prior[DummyParticle, DummyCondition, DummyParameters]):


### PR DESCRIPTION
## Summary
- implement a simple discrete HMM in `seqjax/model/hmm.py`
- add simulation/log-prob test for the HMM

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ccbb2e6c8325948504b97c6c2b11