### PR TITLE
Add Poisson SSM model with tests

### DIFF
--- a/seqjax/model/poisson_ssm.py
+++ b/seqjax/model/poisson_ssm.py
@@ -1,0 +1,130 @@
+"""Simple Poisson state space model."""
+
+from dataclasses import field
+from typing import ClassVar
+
+import jax.numpy as jnp
+import jax.random as jrandom
+import jax.scipy.stats as jstats
+from jaxtyping import PRNGKeyArray, Scalar
+
+from .base import Emission, Prior, SequentialModel, Transition
+from .typing import Condition, Observation, Parameters, Particle
+
+
+class LogRate(Particle):
+    """Latent log-intensity."""
+
+    log_rate: Scalar
+
+
+class CountObservation(Observation):
+    """Observed counts."""
+
+    count: Scalar
+
+
+class PoissonSSMParameters(Parameters):
+    """Model parameters."""
+
+    ar_coeff: Scalar = field(default_factory=lambda: jnp.array(0.9))
+    transition_std: Scalar = field(default_factory=lambda: jnp.array(0.1))
+
+
+class GaussianPrior(Prior[LogRate, Condition, PoissonSSMParameters]):
+    """Gaussian prior over the initial log-rate."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        conditions: tuple[Condition],
+        parameters: PoissonSSMParameters,
+    ) -> tuple[LogRate]:
+        init = parameters.transition_std * jrandom.normal(key)
+        return (LogRate(log_rate=init),)
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[LogRate],
+        conditions: tuple[Condition],
+        parameters: PoissonSSMParameters,
+    ) -> Scalar:
+        return jstats.norm.logpdf(
+            particle[0].log_rate, scale=parameters.transition_std
+        )
+
+
+class GaussianRW(Transition[LogRate, Condition, PoissonSSMParameters]):
+    """Gaussian AR(1) transition on the log-rate."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle_history: tuple[LogRate],
+        condition: Condition,
+        parameters: PoissonSSMParameters,
+    ) -> LogRate:
+        (prev,) = particle_history
+        loc = parameters.ar_coeff * prev.log_rate
+        noise = parameters.transition_std * jrandom.normal(key)
+        return LogRate(log_rate=loc + noise)
+
+    @staticmethod
+    def log_prob(
+        particle_history: tuple[LogRate],
+        particle: LogRate,
+        condition: Condition,
+        parameters: PoissonSSMParameters,
+    ) -> Scalar:
+        (prev,) = particle_history
+        loc = parameters.ar_coeff * prev.log_rate
+        return jstats.norm.logpdf(
+            particle.log_rate, loc=loc, scale=parameters.transition_std
+        )
+
+
+class PoissonEmission(
+    Emission[LogRate, CountObservation, Condition, PoissonSSMParameters]
+):
+    """Poisson emission with rate ``exp(log_rate)``."""
+
+    order: ClassVar[int] = 1
+    observation_dependency: ClassVar[int] = 0
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle: tuple[LogRate],
+        observation_history: tuple[()],
+        condition: Condition,
+        parameters: PoissonSSMParameters,
+    ) -> CountObservation:
+        (current,) = particle
+        rate = jnp.exp(current.log_rate)
+        return CountObservation(count=jrandom.poisson(key, rate))
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[LogRate],
+        observation_history: tuple[()],
+        observation: CountObservation,
+        condition: Condition,
+        parameters: PoissonSSMParameters,
+    ) -> Scalar:
+        (current,) = particle
+        rate = jnp.exp(current.log_rate)
+        return jstats.poisson.logpmf(observation.count, rate)
+
+
+class PoissonSSM(
+    SequentialModel[LogRate, CountObservation, Condition, PoissonSSMParameters]
+):
+    particle_type = LogRate
+    prior = GaussianPrior()
+    transition = GaussianRW()
+    emission = PoissonEmission()
+

--- a/tests/test_filters_integration.py
+++ b/tests/test_filters_integration.py
@@ -12,6 +12,7 @@ from seqjax.model.stochastic_vol import (
     TimeIncrement,
     Underlying,
 )
+from seqjax.model.poisson_ssm import PoissonSSM, PoissonSSMParameters
 
 
 @pytest.mark.parametrize("filter_cls", [BootstrapParticleFilter, AuxiliaryParticleFilter])
@@ -73,6 +74,25 @@ def test_filters_linear_gaussian(filter_cls) -> None:
     log_w, _, _, _, _ = run_filter(
         pf,
         jrandom.PRNGKey(5),
+        params,
+        obs,
+        initial_conditions=(None,),
+    )
+    assert log_w.shape == (pf.num_particles,)
+
+
+@pytest.mark.parametrize("filter_cls", [BootstrapParticleFilter, AuxiliaryParticleFilter])
+def test_filters_poisson_ssm(filter_cls) -> None:
+    seq_len = 5
+
+    key = jrandom.PRNGKey(6)
+    target = PoissonSSM()
+    params = PoissonSSMParameters()
+    _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
+    pf = filter_cls(target, num_particles=5)
+    log_w, _, _, _, _ = run_filter(
+        pf,
+        jrandom.PRNGKey(7),
         params,
         obs,
         initial_conditions=(None,),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from seqjax import simulate, evaluate
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax.model.linear_gaussian import LinearGaussianSSM, LGSSMParameters
 from seqjax.model.stochastic_vol import SimpleStochasticVol, LogVolRW, TimeIncrement
+from seqjax.model.poisson_ssm import PoissonSSM, PoissonSSMParameters
 from seqjax.model.base import Prior, Transition, Emission, SequentialModel
 from seqjax.util import pytree_shape
 from tests.test_typing import (
@@ -65,6 +66,19 @@ def test_simple_stochastic_vol_simulate_length() -> None:
     assert obs.underlying.shape == (3,)
     assert pytree_shape(x_hist)[0][0] == 1
     assert pytree_shape(y_hist)[0][0] == 1
+
+
+def test_poisson_ssm_simulate_length() -> None:
+    key = jax.random.PRNGKey(0)
+    params = PoissonSSMParameters()
+    latent, obs, x_hist, y_hist = simulate.simulate(
+        key, PoissonSSM, None, params, sequence_length=3
+    )
+
+    assert latent.log_rate.shape == (3,)
+    assert obs.count.shape == (3,)
+    logp = evaluate.log_prob_joint(PoissonSSM, latent, obs, None, params)
+    assert jnp.shape(logp) == ()
 
 
 class Prior1(Prior[DummyParticle, DummyCondition, DummyParameters]):


### PR DESCRIPTION
## Summary
- implement `PoissonSSM` with Gaussian random-walk transition and Poisson emission
- add unit tests covering simulation length and particle filter compatibility

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ccc76cb08325b268a41386108e53