### PR TITLE
Add Bayesian NUTS interface

### DIFF
--- a/seqjax/inference/mcmc/__init__.py
+++ b/seqjax/inference/mcmc/__init__.py
@@ -1,3 +1,3 @@
-from .nuts import NUTSConfig, run_nuts
+from .nuts import NUTSConfig, run_nuts, run_bayesian_nuts
 
-__all__ = ["NUTSConfig", "run_nuts"]
+__all__ = ["NUTSConfig", "run_nuts", "run_bayesian_nuts"]

--- a/seqjax/inference/mcmc/nuts.py
+++ b/seqjax/inference/mcmc/nuts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Tuple
 
 import equinox as eqx
 import jax
@@ -13,8 +13,9 @@ from seqjax.model.base import (
     ParametersType,
     ParticleType,
     SequentialModel,
+    ParameterPrior,
 )
-from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.model.typing import Batched, SequenceAxis, HyperParametersType
 from seqjax.model import evaluate
 
 import blackjax
@@ -30,7 +31,9 @@ class NUTSConfig(eqx.Module):
 
 
 def run_nuts(
-    target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType],
+    target: SequentialModel[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ],
     key: PRNGKeyArray,
     parameters: ParametersType,
     observations: Batched[ObservationType, SequenceAxis],
@@ -54,7 +57,9 @@ def run_nuts(
         else config.inverse_mass_matrix
     )
 
-    nuts = blackjax.nuts(logdensity, step_size=config.step_size, inverse_mass_matrix=inv_mass)
+    nuts = blackjax.nuts(
+        logdensity, step_size=config.step_size, inverse_mass_matrix=inv_mass
+    )
     state = nuts.init(initial_latents)
 
     keys = jax.random.split(key, config.num_warmup + config.num_samples)
@@ -69,5 +74,62 @@ def run_nuts(
         state, _ = nuts.step(key, state)
         return state, state.position
 
-    _, samples = jax.lax.scan(sample_step, state, keys[config.num_warmup:])
+    _, samples = jax.lax.scan(sample_step, state, keys[config.num_warmup :])
+    return samples
+
+
+def run_bayesian_nuts(
+    target: SequentialModel[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ],
+    key: PRNGKeyArray,
+    parameter_prior: ParameterPrior[ParametersType, HyperParametersType],
+    observations: Batched[ObservationType, SequenceAxis],
+    *,
+    hyper_parameters: HyperParametersType | None = None,
+    condition: Batched[ConditionType, SequenceAxis] | None = None,
+    initial_latents: Batched[ParticleType, SequenceAxis],
+    initial_parameters: ParametersType,
+    config: NUTSConfig = NUTSConfig(),
+) -> Tuple[
+    Batched[ParticleType, SequenceAxis | int],
+    Batched[ParametersType, SequenceAxis | int],
+]:
+    """Sample parameters and latent paths jointly using NUTS."""
+
+    log_prob_joint = evaluate.get_log_prob_joint_for_target(target)
+
+    def logdensity(state):
+        latents, params = state
+        log_prior = parameter_prior.log_prob(params, hyper_parameters)
+        log_like = log_prob_joint(latents, observations, condition, params)
+        return log_like + log_prior
+
+    init_state = (initial_latents, initial_parameters)
+    flat, _ = jax.flatten_util.ravel_pytree(init_state)
+    dim = flat.shape[0]
+    inv_mass = (
+        jnp.ones(dim)
+        if config.inverse_mass_matrix is None
+        else config.inverse_mass_matrix
+    )
+
+    nuts = blackjax.nuts(
+        logdensity, step_size=config.step_size, inverse_mass_matrix=inv_mass
+    )
+    state = nuts.init(init_state)
+
+    keys = jax.random.split(key, config.num_warmup + config.num_samples)
+
+    def warmup_step(state, key):
+        state, _ = nuts.step(key, state)
+        return state, None
+
+    state, _ = jax.lax.scan(warmup_step, state, keys[: config.num_warmup])
+
+    def sample_step(state, key):
+        state, _ = nuts.step(key, state)
+        return state, state.position
+
+    _, samples = jax.lax.scan(sample_step, state, keys[config.num_warmup :])
     return samples

--- a/tests/test_mcmc_bayesian.py
+++ b/tests/test_mcmc_bayesian.py
@@ -1,0 +1,29 @@
+import jax.random as jrandom
+
+from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax.model import simulate
+from seqjax.inference.mcmc import NUTSConfig, run_bayesian_nuts
+
+
+def test_run_bayesian_nuts_shape() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+    latents, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+
+    config = NUTSConfig(num_warmup=5, num_samples=3, step_size=0.1)
+    sample_key = jrandom.PRNGKey(1)
+    samples_latents, samples_params = run_bayesian_nuts(
+        target,
+        sample_key,
+        HalfCauchyStds(),
+        observations,
+        initial_latents=latents,
+        initial_parameters=parameters,
+        config=config,
+    )
+
+    assert samples_latents.x.shape == (config.num_samples, latents.x.shape[0])
+    assert samples_params.ar.shape == (config.num_samples,)


### PR DESCRIPTION
## Summary
- extend `inference.mcmc.nuts` with `run_bayesian_nuts` for joint parameter and latent sampling
- expose the new function in the `mcmc` package
- test NUTS joint sampling on the AR(1) model

## Testing
- `ruff format seqjax/inference/mcmc/nuts.py seqjax/inference/mcmc/__init__.py tests/test_mcmc_bayesian.py`
- `ruff check seqjax/inference/mcmc/nuts.py seqjax/inference/mcmc/__init__.py tests/test_mcmc_bayesian.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866cd3110408325a01332d57f4b5a67