### PR TITLE
Add scanning to buffered inference loops

### DIFF
--- a/experiments/buffered_sgmcmc/ar1.py
+++ b/experiments/buffered_sgmcmc/ar1.py
@@ -1,0 +1,41 @@
+import matplotlib.pyplot as plt
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.model import simulate
+from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax import (
+    BootstrapParticleFilter,
+    BufferedSGLDConfig,
+    run_buffered_sgld,
+)
+
+
+if __name__ == "__main__":
+    true_params = ARParameters(ar=jnp.array(0.8))
+    key = jrandom.PRNGKey(0)
+    _, obs, _, _ = simulate.simulate(key, AR1Target(), None, true_params, sequence_length=50)
+
+    pf = BootstrapParticleFilter(AR1Target(), num_particles=128)
+    config = BufferedSGLDConfig(
+        step_size=1e-2,
+        num_iters=200,
+        buffer_size=1,
+        batch_size=10,
+        particle_filter=pf,
+        parameter_prior=HalfCauchyStds(),
+    )
+
+    init_params = ARParameters(ar=jnp.array(0.0))
+    samples = run_buffered_sgld(AR1Target(), jrandom.PRNGKey(1), init_params, obs, config=config)
+
+    ar_samples = jnp.asarray(samples.ar)
+    print("True AR parameter:", float(true_params.ar))
+    print("Mean SGLD estimate:", float(jnp.mean(ar_samples)))
+
+    plt.plot(ar_samples, label="sampled ar")
+    plt.axhline(true_params.ar, color="r", linestyle="--", label="true")
+    plt.xlabel("iteration")
+    plt.legend()
+    plt.tight_layout()
+    plt.show()

--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -15,6 +15,12 @@ from .inference.particlefilter import Proposal
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
 from .inference.mcmc import NUTSConfig, run_nuts
+from .inference import (
+    BufferedConfig,
+    run_buffered_filter,
+    BufferedSGLDConfig,
+    run_buffered_sgld,
+)
 
 __all__ = [
     "simulate",
@@ -29,5 +35,8 @@ __all__ = [
     "AuxiliaryParticleFilter",
     "NUTSConfig",
     "run_nuts",
+    "BufferedConfig",
+    "run_buffered_filter",
+    "BufferedSGLDConfig",
+    "run_buffered_sgld",
 ]
-

--- a/seqjax/inference/__init__.py
+++ b/seqjax/inference/__init__.py
@@ -1,0 +1,13 @@
+from .buffered import (
+    BufferedConfig,
+    run_buffered_filter,
+    BufferedSGLDConfig,
+    run_buffered_sgld,
+)
+
+__all__ = [
+    "BufferedConfig",
+    "run_buffered_filter",
+    "BufferedSGLDConfig",
+    "run_buffered_sgld",
+]

--- a/seqjax/inference/buffered/__init__.py
+++ b/seqjax/inference/buffered/__init__.py
@@ -1,0 +1,11 @@
+"""Buffered inference utilities."""
+
+from .buffered import BufferedConfig, run_buffered_filter
+from .sgmcmc import BufferedSGLDConfig, run_buffered_sgld
+
+__all__ = [
+    "BufferedConfig",
+    "run_buffered_filter",
+    "BufferedSGLDConfig",
+    "run_buffered_sgld",
+]

--- a/seqjax/inference/buffered/buffered.py
+++ b/seqjax/inference/buffered/buffered.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import PRNGKeyArray
+from typing import Any
+
+from seqjax.model.base import (
+    ConditionType,
+    ObservationType,
+    ParametersType,
+    ParticleType,
+    SequentialModel,
+)
+from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.util import (
+    dynamic_index_pytree_in_dim,
+    dynamic_slice_pytree,
+)
+from seqjax.inference.particlefilter import SMCSampler, run_filter
+
+
+def _pad_edges_pytree(tree: Any, pad: int) -> Any:
+    """Pad ``tree`` on the leading and trailing sequence axes using edge values."""
+
+    def _pad(x: jax.Array) -> jax.Array:
+        pad_width = [(pad, pad)] + [(0, 0)] * (x.ndim - 1)
+        return jnp.pad(x, pad_width, mode="edge")
+
+    return jax.tree_util.tree_map(_pad, tree)
+
+
+class BufferedConfig(eqx.Module):
+    """Configuration for :func:`run_buffered_filter`."""
+
+    buffer_size: int = 0
+    batch_size: int = 1
+    particle_filter: SMCSampler[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ] | None = None
+
+
+def _run_segment(
+    start: int,
+    smc: SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType],
+    key: PRNGKeyArray,
+    parameters: ParametersType,
+    observations: Batched[ObservationType, SequenceAxis],
+    condition_path: Batched[ConditionType, SequenceAxis] | None,
+    *,
+    buffer_size: int,
+    batch_size: int,
+) -> jax.Array:
+    """Run filtering over a buffered segment starting at ``start``."""
+
+    slice_size = batch_size + 2 * buffer_size
+
+    obs_padded = _pad_edges_pytree(observations, buffer_size)
+    if condition_path is not None:
+        cond_padded = _pad_edges_pytree(condition_path, buffer_size)
+    else:
+        cond_padded = None
+
+    obs_slice = dynamic_slice_pytree(obs_padded, start, slice_size)
+    if condition_path is not None:
+        cond_slice = dynamic_slice_pytree(cond_padded, start, slice_size)
+    else:
+        cond_slice = None
+
+    if smc.target.prior.order > 0:
+        init_conds = tuple(
+            dynamic_index_pytree_in_dim(cond_padded, start + i, 0)
+            if cond_padded is not None
+            else None
+            for i in range(smc.target.prior.order)
+        )
+    else:
+        init_conds = ()
+
+    _, _, log_mp_hist, _, _ = run_filter(
+        smc,
+        key,
+        parameters,
+        obs_slice,
+        cond_slice,
+        initial_conditions=init_conds,
+    )
+
+    return log_mp_hist[buffer_size : buffer_size + batch_size]
+
+
+def run_buffered_filter(
+    target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType],
+    key: PRNGKeyArray,
+    parameters: ParametersType,
+    observations: Batched[ObservationType, SequenceAxis],
+    *,
+    condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+    config: BufferedConfig,
+) -> jax.Array:
+    """Run buffered particle filtering over ``observations``."""
+
+    smc = config.particle_filter
+    if smc is None:
+        raise ValueError("particle_filter must be provided in config")
+    if smc.target is not target:
+        smc = eqx.tree_at(lambda m: m.target, smc, target)
+    seq_len = jax.tree_util.tree_leaves(observations)[0].shape[0]
+    starts = jnp.arange(0, seq_len, config.batch_size)
+    keys = jax.random.split(key, len(starts))
+
+    def step(_, inp):
+        s, k = inp
+        logmps = _run_segment(
+            s,
+            smc,
+            k,
+            parameters,
+            observations,
+            condition_path,
+            buffer_size=config.buffer_size,
+            batch_size=config.batch_size,
+        )
+        return None, logmps
+
+    _, seg_logmps = jax.lax.scan(step, None, (starts, keys))
+
+    return jnp.concatenate(seg_logmps)[:seq_len]

--- a/seqjax/inference/buffered/sgmcmc.py
+++ b/seqjax/inference/buffered/sgmcmc.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import PRNGKeyArray
+
+from seqjax.model.base import (
+    ConditionType,
+    ObservationType,
+    ParametersType,
+    ParticleType,
+    SequentialModel,
+    ParameterPrior,
+    HyperParametersType,
+)
+from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.inference.particlefilter import SMCSampler
+from .buffered import _run_segment
+
+
+class BufferedSGLDConfig(eqx.Module):
+    """Configuration for :func:`run_buffered_sgld`."""
+
+    step_size: float = 1e-3
+    num_iters: int = 100
+    buffer_size: int = 0
+    batch_size: int = 1
+    particle_filter: SMCSampler[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ] | None = None
+    parameter_prior: ParameterPrior[ParametersType, HyperParametersType] | None = None
+    hyperparameters: HyperParametersType | None = None
+
+
+def _tree_randn_like(key: PRNGKeyArray, tree: ParametersType) -> ParametersType:
+    leaves, treedef = jax.tree_util.tree_flatten(tree)
+    keys = jrandom.split(key, len(leaves))
+    new_leaves = [
+        jrandom.normal(k, shape=jnp.shape(leaf)) for k, leaf in zip(keys, leaves)
+    ]
+    return jax.tree_util.tree_unflatten(treedef, new_leaves)
+
+
+def run_buffered_sgld(
+    target: SequentialModel[ParticleType, ObservationType, ConditionType, ParametersType],
+    key: PRNGKeyArray,
+    parameters: ParametersType,
+    observations: Batched[ObservationType, SequenceAxis],
+    *,
+    condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+    config: BufferedSGLDConfig,
+) -> Batched[ParametersType, SequenceAxis | int]:
+    """Run buffered SGLD updates over ``observations``."""
+
+    smc = config.particle_filter
+    if smc is None:
+        raise ValueError("particle_filter must be provided in config")
+    if smc.target is not target:
+        smc = eqx.tree_at(lambda m: m.target, smc, target)
+    prior = config.parameter_prior
+    if prior is None:
+        raise ValueError("parameter_prior must be provided in config")
+
+    seq_len = jax.tree_util.tree_leaves(observations)[0].shape[0]
+    if config.batch_size > seq_len:
+        raise ValueError("batch_size must not exceed sequence length")
+
+    start_max = seq_len - config.batch_size + 1
+    n_iters = config.num_iters
+    split_keys = jrandom.split(key, 2 * n_iters + 1)
+    start_key, pf_keys, noise_keys = (
+        split_keys[0],
+        split_keys[1 : n_iters + 1],
+        split_keys[n_iters + 1 :],
+    )
+    starts = jrandom.randint(start_key, shape=(n_iters,), minval=0, maxval=start_max)
+
+    def step(params: ParametersType, inp: tuple[PRNGKeyArray, PRNGKeyArray, jax.Array]):
+        pf_key, noise_key, start = inp
+
+        def log_post(p: ParametersType) -> jax.Array:
+            log_mps = _run_segment(
+                start,
+                smc,
+                pf_key,
+                p,
+                observations,
+                condition_path,
+                buffer_size=config.buffer_size,
+                batch_size=config.batch_size,
+            )
+            return prior.log_prob(p, config.hyperparameters) + jnp.sum(log_mps)
+
+        grad = jax.grad(log_post)(params)
+        noise = _tree_randn_like(noise_key, params)
+        updates = jax.tree_util.tree_map(
+            lambda g, n: 0.5 * config.step_size * g + jnp.sqrt(config.step_size) * n,
+            grad,
+            noise,
+        )
+        params = eqx.apply_updates(params, updates)
+        return params, params
+
+    _, samples = jax.lax.scan(step, parameters, (pf_keys, noise_keys, starts))
+    return samples

--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -66,16 +66,15 @@ def slice_pytree(tree: Any, start_index: int, limit_index: int, dim: int = 0) ->
 def dynamic_slice_pytree(
     tree: Any,
     start_index: int,
-    limit_index: int,
+    slice_size: int,
     dim: int = 0,
 ) -> Any:
     """Dynamically slice a pytree along ``dim``."""
-
     return jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
-            limit_index=limit_index,
+            slice_size=slice_size,
             axis=dim,
         ),
         tree,

--- a/tests/test_buffered.py
+++ b/tests/test_buffered.py
@@ -1,0 +1,18 @@
+import jax.random as jrandom
+
+from seqjax.model.ar import AR1Target, ARParameters
+from seqjax import simulate, BootstrapParticleFilter
+from seqjax.inference.buffered import BufferedConfig, run_buffered_filter
+
+
+def test_buffered_filter_shape() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    params = ARParameters()
+    _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=5)
+
+    pf = BootstrapParticleFilter(target, num_particles=4)
+    config = BufferedConfig(buffer_size=1, batch_size=2, particle_filter=pf)
+    log_mps = run_buffered_filter(target, jrandom.PRNGKey(1), params, obs, config=config)
+
+    assert log_mps.shape == (obs.y.shape[0],)

--- a/tests/test_buffered_sgld.py
+++ b/tests/test_buffered_sgld.py
@@ -1,0 +1,26 @@
+import jax.random as jrandom
+
+from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax import simulate, BootstrapParticleFilter
+from seqjax.inference.buffered import BufferedSGLDConfig, run_buffered_sgld
+
+
+def test_buffered_sgld_runs() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    params = ARParameters()
+    prior = HalfCauchyStds()
+    _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=5)
+
+    pf = BootstrapParticleFilter(target, num_particles=4)
+    config = BufferedSGLDConfig(
+        step_size=0.1,
+        num_iters=3,
+        buffer_size=1,
+        batch_size=2,
+        particle_filter=pf,
+        parameter_prior=prior,
+    )
+    samples = run_buffered_sgld(target, jrandom.PRNGKey(1), params, obs, config=config)
+
+    assert samples.ar.shape == (config.num_iters,)


### PR DESCRIPTION
## Summary
- enable JAX scanning in `run_buffered_filter`
- refactor `_run_segment` to support dynamic slicing
- implement `run_buffered_sgld` with `jax.lax.scan`
- add helper to pad edges and update util API
- add AR(1) buffered SGLD demonstration script

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866c3913cf08325bb2f58eb5bc57d18