### PR TITLE
Add AR(1) log-probability test

### DIFF
--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -69,16 +69,13 @@ def dynamic_slice_pytree(
     slice_size: int,
     dim: int = 0,
 ) -> Any:
-    """Dynamically slice a pytree along ``dim``."""
-
-
+    """Dynamically slice a pytree along ``dim`` with a fixed ``slice_size``."""
 
     return jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
             slice_size=slice_size,
-            slice_size=limit_index - start_index,
             axis=dim,
         ),
         tree,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ import pytest
 jax = pytest.importorskip("jax")
 import jax.numpy as jnp
 import jax.random as jrandom
+import jax.scipy.stats as jstats
 
 
 from seqjax import simulate, evaluate
@@ -306,3 +307,30 @@ def test_simulate_dependency_lengths(
         assert pytree_shape(obs)[0][0] == seq_len
         assert pytree_shape(x_hist)[0][0] == target.prior.order - 1
         assert pytree_shape(y_hist)[0][0] == obs_dep
+
+
+def test_ar1_joint_log_prob_closed_form() -> None:
+    key = jrandom.PRNGKey(0)
+    params = ARParameters(
+        ar=jnp.array(0.5),
+        observation_std=jnp.array(1.0),
+        transition_std=jnp.array(0.3),
+    )
+    latents, observations, _, _ = simulate.simulate(
+        key, AR1Target, None, params, sequence_length=3
+    )
+
+    x = latents.x
+    y = observations.y
+
+    manual_logp = jstats.norm.logpdf(x[0], loc=0.0, scale=params.transition_std)
+    manual_logp += jstats.norm.logpdf(y[0], loc=x[0], scale=params.observation_std)
+    manual_logp += jnp.sum(
+        jstats.norm.logpdf(x[1:], loc=params.ar * x[:-1], scale=params.transition_std)
+    )
+    manual_logp += jnp.sum(
+        jstats.norm.logpdf(y[1:], loc=x[1:], scale=params.observation_std)
+    )
+
+    eval_logp = evaluate.log_prob_joint(AR1Target, latents, observations, None, params)
+    assert jnp.allclose(manual_logp, eval_logp)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,7 +23,7 @@ def test_dynamic_slice_pytree_matches_lax() -> None:
     start_index = 2
     limit_index = 7
 
-    sliced = dynamic_slice_pytree(tree, start_index, limit_index)
+    sliced = dynamic_slice_pytree(tree, start_index, limit_index - start_index)
     expected = jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,


### PR DESCRIPTION
## Summary
- fix `dynamic_slice_pytree` implementation and adjust util tests
- add missing `jstats` import for model tests
- verify AR(1) joint log probability via closed-form formula

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d4ba1e188325834dd6168623f3e2