### PR TITLE
Remove unused logp assignments

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,7 +83,6 @@ def test_sir_simulate_length() -> None:
 
     assert latent.s.shape == (3,)
     assert obs.new_cases.shape == (3,)
-    logp = evaluate.log_prob_joint(SIRModel, latent, obs, None, params)
 
 
 def test_poisson_ssm_simulate_length() -> None:
@@ -95,7 +94,6 @@ def test_poisson_ssm_simulate_length() -> None:
 
     assert latent.log_rate.shape == (3,)
     assert obs.count.shape == (3,)
-    logp = evaluate.log_prob_joint(PoissonSSM, latent, obs, None, params)
 
 def test_hmm_simulate_length() -> None:
     key = jax.random.PRNGKey(0)


### PR DESCRIPTION
## Summary
- clean up tests by removing unused `logp` variables

## Testing
- `ruff check tests/test_models.py`

------
https://chatgpt.com/codex/tasks/task_e_6866d50173488325bf90328f7ae65b35