### PR TITLE
Add posterior mean checks for MCMC and PMCMC

### DIFF
--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -70,15 +70,11 @@ def dynamic_slice_pytree(
     dim: int = 0,
 ) -> Any:
     """Dynamically slice a pytree along ``dim``."""
-
-
-
     return jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
             slice_size=slice_size,
-            slice_size=limit_index - start_index,
             axis=dim,
         ),
         tree,

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,4 +1,5 @@
 import jax.random as jrandom
+import jax.numpy as jnp
 
 from seqjax.model.ar import AR1Target, ARParameters
 from seqjax.model import simulate
@@ -25,3 +26,28 @@ def test_run_nuts_shape() -> None:
     )
 
     assert samples.x.shape == (config.num_samples, latents.x.shape[0])
+
+
+def test_run_nuts_recovers_latents() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    true_params = ARParameters(
+        ar=jnp.array(0.7), observation_std=jnp.array(0.05), transition_std=jnp.array(0.05)
+    )
+    latents, observations, _, _ = simulate.simulate(
+        key, target, None, true_params, sequence_length=3
+    )
+
+    config = NUTSConfig(num_warmup=10, num_samples=20, step_size=0.03)
+    sample_key = jrandom.PRNGKey(1)
+    samples = run_nuts(
+        target,
+        sample_key,
+        true_params,
+        observations,
+        initial_latents=latents,
+        config=config,
+    )
+
+    mean_latents = jnp.mean(samples.x, axis=0)
+    assert jnp.allclose(mean_latents, latents.x, atol=0.1)

--- a/tests/test_pmcmc.py
+++ b/tests/test_pmcmc.py
@@ -1,4 +1,5 @@
 import jax.random as jrandom
+import jax.numpy as jnp
 
 from seqjax.inference.pmcmc import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
 from seqjax.inference.particlefilter import BootstrapParticleFilter
@@ -31,3 +32,33 @@ def test_run_particle_mcmc_shape() -> None:
     )
 
     assert samples.ar.shape == (config.mcmc.num_samples,)
+
+
+def test_run_particle_mcmc_recovers_params() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    true_params = ARParameters(
+        ar=jnp.array(0.6), observation_std=jnp.array(0.05), transition_std=jnp.array(0.05)
+    )
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, true_params, sequence_length=4
+    )
+
+    pf = BootstrapParticleFilter(target, num_particles=10)
+    config = ParticleMCMCConfig(
+        mcmc=RandomWalkConfig(step_size=0.05, num_samples=20),
+        particle_filter=pf,
+    )
+    sample_key = jrandom.PRNGKey(1)
+    samples = run_particle_mcmc(
+        target,
+        sample_key,
+        HalfCauchyStds(),
+        observations,
+        config=config,
+        initial_parameters=true_params,
+        initial_conditions=(None,),
+    )
+
+    mean_ar = jnp.mean(samples.ar)
+    assert jnp.allclose(mean_ar, true_params.ar, atol=0.1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,14 +21,14 @@ def test_dynamic_slice_pytree_matches_lax() -> None:
 
     tree = {"a": jnp.arange(10), "b": jnp.arange(10) * 2}
     start_index = 2
-    limit_index = 7
+    slice_size = 5
 
-    sliced = dynamic_slice_pytree(tree, start_index, limit_index)
+    sliced = dynamic_slice_pytree(tree, start_index, slice_size)
     expected = jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
-            slice_size=limit_index - start_index,
+            slice_size=slice_size,
             axis=0,
         ),
         tree,


### PR DESCRIPTION
## Summary
- fix `dynamic_slice_pytree` and update util tests
- add convergence checks in MCMC/PMCMC tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866d4c8da7483259a7da92e76b74dfb