### PR TITLE
Add logistic regression SMC experiment

### DIFF
--- a/experiments/smc/logistic_regression.py
+++ b/experiments/smc/logistic_regression.py
@@ -1,0 +1,73 @@
+import matplotlib.pyplot as plt
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.inference.particlefilter import (
+    BootstrapParticleFilter,
+    current_particle_mean,
+    current_particle_quantiles,
+    run_filter,
+)
+from seqjax.model.logistic_smc import (
+    LogisticRegressionSMC,
+    LogRegData,
+    AnnealCondition,
+    DummyObservation,
+)
+
+
+if __name__ == "__main__":
+    # simulate a 2d logistic regression dataset
+    n, d = 200, 2
+    key = jrandom.key(0)
+    k1, k2, k3 = jrandom.split(key, 3)
+    theta_true = jrandom.normal(k1, shape=(d,))
+    X = jrandom.normal(k2, shape=(n, d))
+    logits = X @ theta_true
+    y = jrandom.bernoulli(k3, jax.nn.sigmoid(logits))
+    data = LogRegData(X=X, y=y)
+
+    # annealing schedule from beta=0 -> 1
+    num_steps = 20
+    betas = jnp.linspace(0.0, 1.0, num_steps + 1)
+    cond_path = AnnealCondition(beta=betas[1:], beta_prev=betas[:-1])
+    obs_path = DummyObservation(dummy=jnp.zeros(num_steps))
+
+    model = LogisticRegressionSMC()
+    pf = BootstrapParticleFilter(model, num_particles=1000)
+    init_cond = (AnnealCondition(beta=betas[0], beta_prev=betas[0]),)
+
+    mean_rec = current_particle_mean(lambda p: p.theta)
+    quant_rec = current_particle_quantiles(lambda p: p.theta, quantiles=(0.05, 0.95))
+
+    log_w, particles, _, ess, (theta_mean, theta_quant) = run_filter(
+        pf,
+        jrandom.key(1),
+        data,
+        obs_path,
+        cond_path,
+        initial_conditions=init_cond,
+        recorders=(mean_rec, quant_rec),
+    )
+
+    weights = jax.nn.softmax(log_w)
+    theta_samples = particles[-1].theta
+
+    plt.figure(figsize=(6, 5))
+    plt.scatter(theta_samples[:, 0], theta_samples[:, 1], c=weights, cmap="viridis", s=10, alpha=0.7)
+    plt.scatter(theta_true[0], theta_true[1], color="red", marker="x", label="true")
+    plt.xlabel(r"$\\theta_1$")
+    plt.ylabel(r"$\\theta_2$")
+    plt.colorbar(label="weight")
+    plt.title("SMC posterior for logistic regression")
+    plt.legend()
+    plt.tight_layout()
+    plt.show()
+
+    t = jnp.arange(num_steps)
+    plt.figure(figsize=(6, 3))
+    plt.plot(t, ess)
+    plt.title("ESS across annealing steps")
+    plt.tight_layout()
+    plt.show()

--- a/seqjax/model/logistic_smc.py
+++ b/seqjax/model/logistic_smc.py
@@ -1,0 +1,139 @@
+"""Logistic regression SMC sampler example."""
+
+from dataclasses import field
+from typing import ClassVar
+
+import jax.numpy as jnp
+import jax.random as jrandom
+import jax.scipy.stats as jstats
+from jaxtyping import PRNGKeyArray, Scalar
+
+from seqjax.model.base import Emission, Prior, SequentialModel, Transition
+from seqjax.model.typing import (
+    Condition,
+    Observation,
+    Parameters,
+    Particle,
+)
+
+
+class LogRegParticle(Particle):
+    """Latent logistic regression parameters."""
+
+    theta: jnp.ndarray  # shape (d,)
+
+
+class LogRegData(Parameters):
+    """Fixed dataset used as model parameters."""
+
+    X: jnp.ndarray  # shape (n, d)
+    y: jnp.ndarray  # shape (n,)
+    reference_emission: tuple[Observation] = field(default_factory=tuple)
+
+
+class DummyObservation(Observation):
+    """Placeholder observation carrying a scalar value."""
+
+    dummy: Scalar = field(default_factory=lambda: jnp.array(0.0))
+
+
+class AnnealCondition(Condition):
+    """Annealing level."""
+
+    beta: Scalar
+    beta_prev: Scalar
+
+
+class GaussianPrior(Prior[LogRegParticle, AnnealCondition, LogRegData]):
+    """Wide Gaussian prior over the regression coefficients."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        conditions: tuple[AnnealCondition],
+        parameters: LogRegData,
+    ) -> tuple[LogRegParticle]:
+        (cond,) = conditions
+        _ = cond  # unused
+        theta = 10.0 * jrandom.normal(key, shape=(parameters.X.shape[1],))
+        return (LogRegParticle(theta=theta),)
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[LogRegParticle],
+        conditions: tuple[AnnealCondition],
+        parameters: LogRegData,
+    ) -> Scalar:
+        (theta,) = particle
+        return jstats.norm.logpdf(theta.theta, loc=0.0, scale=10.0).sum()
+
+
+class RWTransition(Transition[LogRegParticle, AnnealCondition, LogRegData]):
+    """Random walk Metropolis proposal (symmetric)."""
+
+    order: ClassVar[int] = 1
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle_history: tuple[LogRegParticle],
+        condition: AnnealCondition,
+        parameters: LogRegData,
+    ) -> LogRegParticle:
+        (state,) = particle_history
+        step = 0.5 * jrandom.normal(key, shape=state.theta.shape)
+        return LogRegParticle(theta=state.theta + step)
+
+    @staticmethod
+    def log_prob(
+        particle_history: tuple[LogRegParticle],
+        particle: LogRegParticle,
+        condition: AnnealCondition,
+        parameters: LogRegData,
+    ) -> Scalar:
+        return jnp.array(0.0)
+
+
+class TemperedEmission(
+    Emission[LogRegParticle, DummyObservation, AnnealCondition, LogRegData]
+):
+    """Incremental weight using tempering."""
+
+    order: ClassVar[int] = 1
+    observation_dependency: ClassVar[int] = 0
+
+    @staticmethod
+    def sample(
+        key: PRNGKeyArray,
+        particle: tuple[LogRegParticle],
+        observation_history: tuple[()],
+        condition: AnnealCondition,
+        parameters: LogRegData,
+    ) -> DummyObservation:
+        return DummyObservation()
+
+    @staticmethod
+    def log_prob(
+        particle: tuple[LogRegParticle],
+        observation_history: tuple[()],
+        observation: DummyObservation,
+        condition: AnnealCondition,
+        parameters: LogRegData,
+    ) -> Scalar:
+        (state,) = particle
+        logits = parameters.X @ state.theta
+        loglik = jnp.sum(parameters.y * logits - jnp.logaddexp(0.0, logits))
+        return (condition.beta - condition.beta_prev) * loglik
+
+
+class LogisticRegressionSMC(
+    SequentialModel[LogRegParticle, DummyObservation, AnnealCondition, LogRegData]
+):
+    """SequentialModel wrapping the tempered logistic regression components."""
+
+    prior = GaussianPrior()
+    transition = RWTransition()
+    emission = TemperedEmission()
+

--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -77,8 +77,6 @@ def dynamic_slice_pytree(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
             slice_size=slice_size,
-            slice_size=limit_index - start_index,
-
             axis=dim,
         ),
         tree,

--- a/tests/test_logistic_smc.py
+++ b/tests/test_logistic_smc.py
@@ -1,0 +1,42 @@
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.inference.particlefilter import BootstrapParticleFilter, run_filter
+from seqjax.model.logistic_smc import (
+    LogisticRegressionSMC,
+    LogRegData,
+    AnnealCondition,
+    DummyObservation,
+)
+
+
+def test_logistic_smc_runs() -> None:
+    key = jrandom.PRNGKey(0)
+    n, d = 5, 2
+    k1, k2, k3 = jrandom.split(key, 3)
+    theta_true = jrandom.normal(k1, shape=(d,))
+    X = jrandom.normal(k2, shape=(n, d))
+    logits = X @ theta_true
+    y = jrandom.bernoulli(k3, jax.nn.sigmoid(logits))
+    data = LogRegData(X=X, y=y)
+
+    betas = jnp.linspace(0.0, 1.0, 4)
+    cond_path = AnnealCondition(beta=betas[1:], beta_prev=betas[:-1])
+    obs_path = DummyObservation(dummy=jnp.zeros(len(betas) - 1))
+
+    model = LogisticRegressionSMC()
+    pf = BootstrapParticleFilter(model, num_particles=20)
+    log_w, particles, log_mp, ess, _ = run_filter(
+        pf,
+        jrandom.PRNGKey(1),
+        data,
+        observation_path=obs_path,
+        condition_path=cond_path,
+        initial_conditions=(AnnealCondition(beta=betas[0], beta_prev=betas[0]),),
+    )
+
+    assert log_w.shape == (pf.num_particles,)
+    seq_len = betas.shape[0] - 1
+    assert log_mp.shape[0] == seq_len
+    assert ess.shape[0] == seq_len


### PR DESCRIPTION
## Summary
- add example script to run a tempered SMC sampler for logistic regression

## Testing
- `ruff check seqjax/model/logistic_smc.py tests/test_logistic_smc.py seqjax/util.py experiments/smc/logistic_regression.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866cd88e6b88325a6b91e6db7938da9