### PR TITLE
Add pytree utility tests and fix slicing

### DIFF
--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -71,14 +71,11 @@ def dynamic_slice_pytree(
 ) -> Any:
     """Dynamically slice a pytree along ``dim``."""
 
-
-
     return jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
             slice_size=slice_size,
-            slice_size=limit_index - start_index,
             axis=dim,
         ),
         tree,

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -29,6 +29,16 @@ class DummyParameters(Parameters):
     )
 
 
+class MultiParticle(Particle):
+    x: Scalar = eqx.field(default_factory=lambda: jnp.array(0.0))
+    y: Scalar = eqx.field(default_factory=lambda: jnp.array(0.0))
+
+
+class MultiObservation(Observation):
+    x: Scalar = eqx.field(default_factory=lambda: jnp.array(0.0))
+    y: Scalar = eqx.field(default_factory=lambda: jnp.array(0.0))
+
+
 class GoodPrior(Prior[DummyParticle, DummyCondition, DummyParameters]):
     order: ClassVar[int] = 1
 
@@ -128,6 +138,23 @@ def test_prior_missing_staticmethod() -> None:
                 parameters: DummyParameters,
             ) -> Scalar:
                 return jnp.array(0.0)
+
+
+def test_as_array_helpers() -> None:
+    """``Particle.as_array`` and ``Observation.as_array`` stack leaf values."""
+
+    p = MultiParticle(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0]))
+    o = MultiObservation(jnp.array([5.0, 6.0]), jnp.array([7.0, 8.0]))
+
+    expected_p = jnp.dstack(
+        [jnp.expand_dims(p.x, -1), jnp.expand_dims(p.y, -1)]
+    )
+    expected_o = jnp.dstack(
+        [jnp.expand_dims(o.x, -1), jnp.expand_dims(o.y, -1)]
+    )
+
+    assert jnp.array_equal(p.as_array(), expected_p)
+    assert jnp.array_equal(o.as_array(), expected_o)
 
 
 def test_prior_order_mismatch() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 from functools import partial
 
-from seqjax.util import dynamic_slice_pytree, pytree_shape
+from seqjax.util import concat_pytree, index_pytree, dynamic_slice_pytree, pytree_shape
 
 
 def test_pytree_shape_dict() -> None:
@@ -21,14 +21,14 @@ def test_dynamic_slice_pytree_matches_lax() -> None:
 
     tree = {"a": jnp.arange(10), "b": jnp.arange(10) * 2}
     start_index = 2
-    limit_index = 7
+    slice_size = 5
 
-    sliced = dynamic_slice_pytree(tree, start_index, limit_index)
+    sliced = dynamic_slice_pytree(tree, start_index, slice_size)
     expected = jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
-            slice_size=limit_index - start_index,
+            slice_size=slice_size,
             axis=0,
         ),
         tree,
@@ -37,3 +37,31 @@ def test_dynamic_slice_pytree_matches_lax() -> None:
     assert jax.tree_util.tree_all(  # type: ignore[call-arg]
         jax.tree_util.tree_map(lambda x, y: jnp.array_equal(x, y), sliced, expected)
     )
+
+
+def test_index_pytree_basic() -> None:
+    """``index_pytree`` should index leaves along the first dimension."""
+
+    tree = {
+        "a": jnp.arange(6).reshape(3, 2),
+        "b": jnp.arange(9).reshape(3, 3),
+    }
+
+    single = index_pytree(tree, 1)
+    assert jnp.array_equal(single["a"], jnp.array([2, 3]))
+    assert jnp.array_equal(single["b"], jnp.array([3, 4, 5]))
+
+    nested = index_pytree(tree, (1, 0))
+    assert jnp.array_equal(nested["a"], jnp.array(2))
+    assert jnp.array_equal(nested["b"], jnp.array(3))
+
+
+def test_concat_pytree_basic() -> None:
+    """``concat_pytree`` should concatenate matching leaves."""
+
+    tree1 = {"a": jnp.array([1, 2]), "b": jnp.array([3, 4])}
+    tree2 = {"a": jnp.array([5, 6]), "b": jnp.array([7, 8])}
+
+    result = concat_pytree(tree1, tree2, axis=0)
+    assert jnp.array_equal(result["a"], jnp.array([1, 2, 5, 6]))
+    assert jnp.array_equal(result["b"], jnp.array([3, 4, 7, 8]))


### PR DESCRIPTION
## Summary
- fix `dynamic_slice_pytree` signature
- extend util tests for `index_pytree` and `concat_pytree`
- add tests for `Particle.as_array` and `Observation.as_array`

## Testing
- `ruff check seqjax/util.py tests/test_util.py tests/test_typing.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d4cedc108325a3d4d6cd2e56dfdf