### PR TITLE
Add InferenceMethod protocol and update inference API

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -14,7 +14,8 @@ from .inference.particlefilter import Proposal
 
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
-from .inference.mcmc import NUTSConfig, run_nuts
+from .inference.mcmc import NUTSConfig, run_nuts, run_bayesian_nuts
+from .inference.interface import InferenceMethod
 from .inference import (
     BufferedConfig,
     run_buffered_filter,
@@ -35,6 +36,8 @@ __all__ = [
     "AuxiliaryParticleFilter",
     "NUTSConfig",
     "run_nuts",
+    "run_bayesian_nuts",
+    "InferenceMethod",
     "BufferedConfig",
     "run_buffered_filter",
     "BufferedSGLDConfig",

--- a/seqjax/inference/__init__.py
+++ b/seqjax/inference/__init__.py
@@ -1,3 +1,4 @@
+from .interface import InferenceMethod
 from .buffered import (
     BufferedConfig,
     run_buffered_filter,
@@ -6,6 +7,7 @@ from .buffered import (
 )
 
 __all__ = [
+    "InferenceMethod",
     "BufferedConfig",
     "run_buffered_filter",
     "BufferedSGLDConfig",

--- a/seqjax/inference/interface.py
+++ b/seqjax/inference/interface.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+from jaxtyping import PRNGKeyArray
+
+from seqjax.model.base import (
+    SequentialModel,
+    ParticleType,
+    ObservationType,
+    ConditionType,
+    ParametersType,
+    ParameterPrior,
+)
+from seqjax.model.typing import Batched, SequenceAxis, HyperParametersType
+
+
+class InferenceMethod(Protocol):
+    """Callable protocol for Bayesian inference routines.
+
+    This interface represents the minimal call signature shared by the
+    Bayesian samplers provided in :mod:`seqjax`. Concrete inference functions
+    such as :func:`~seqjax.inference.mcmc.run_nuts` should be partially applied
+    with any algorithm-specific configuration before being used through this
+    protocol.
+    """
+
+    def __call__(
+        self,
+        target: SequentialModel[
+            ParticleType, ObservationType, ConditionType, ParametersType
+        ],
+        key: PRNGKeyArray,
+        observations: Batched[ObservationType, SequenceAxis],
+        *,
+        parameter_prior: (
+            ParameterPrior[ParametersType, HyperParametersType] | None
+        ) = None,
+        condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+        initial_latents: Batched[ParticleType, SequenceAxis] | None = None,
+        hyper_parameters: HyperParametersType | None = None,
+        initial_conditions: tuple[ConditionType, ...] | None = None,
+        observation_history: tuple[ObservationType, ...] | None = None,
+    ) -> Any: ...

--- a/seqjax/inference/pmcmc/pmmh.py
+++ b/seqjax/inference/pmcmc/pmmh.py
@@ -76,13 +76,15 @@ def _log_density(
 def run_particle_mcmc(
     target: SequentialModel[ParticleType, ObservationType, ConditionType, Parameters],
     key: jrandom.PRNGKey,
-    parameter_prior: ParameterPrior[Parameters, HyperParametersType],
     observations: Batched[ObservationType, SequenceAxis],
     *,
+    parameter_prior: ParameterPrior[Parameters, HyperParametersType],
     config: ParticleMCMCConfig,
-    hyper_parameters: HyperParametersType | None = None,
     initial_parameters: Parameters,
     condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+    hyper_parameters: HyperParametersType | None = None,
+    initial_latents: Batched[ParticleType, SequenceAxis] | None = None,
+    parameters: Parameters | None = None,
     initial_conditions: tuple[ConditionType, ...] | None = None,
     observation_history: tuple[ObservationType, ...] | None = None,
 ) -> Batched[Parameters, SequenceAxis | int]:

--- a/seqjax/util.py
+++ b/seqjax/util.py
@@ -71,18 +71,12 @@ def dynamic_slice_pytree(
 ) -> Any:
     """Dynamically slice a pytree along ``dim``."""
 
+    def _slice(x: Any) -> Any:
+        return jax.lax.dynamic_slice_in_dim(
+            x, start_index=start_index, slice_size=slice_size, axis=dim
+        )
 
-
-    return jax.tree_util.tree_map(
-        partial(
-            jax.lax.dynamic_slice_in_dim,
-            start_index=start_index,
-            slice_size=slice_size,
-            slice_size=limit_index - start_index,
-            axis=dim,
-        ),
-        tree,
-    )
+    return jax.tree_util.tree_map(_slice, tree)
 
 
 def concat_pytree(*trees: Any, axis: int = 0) -> Any:

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -18,8 +18,8 @@ def test_run_nuts_shape() -> None:
     samples = run_nuts(
         target,
         sample_key,
-        parameters,
         observations,
+        parameters=parameters,
         initial_latents=latents,
         config=config,
     )

--- a/tests/test_mcmc_bayesian.py
+++ b/tests/test_mcmc_bayesian.py
@@ -18,8 +18,8 @@ def test_run_bayesian_nuts_shape() -> None:
     samples_latents, samples_params = run_bayesian_nuts(
         target,
         sample_key,
-        HalfCauchyStds(),
         observations,
+        parameter_prior=HalfCauchyStds(),
         initial_latents=latents,
         initial_parameters=parameters,
         config=config,

--- a/tests/test_pmcmc.py
+++ b/tests/test_pmcmc.py
@@ -23,8 +23,8 @@ def test_run_particle_mcmc_shape() -> None:
     samples = run_particle_mcmc(
         target,
         sample_key,
-        HalfCauchyStds(),
         observations,
+        parameter_prior=HalfCauchyStds(),
         config=config,
         initial_parameters=parameters,
         initial_conditions=(None,),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,14 +21,14 @@ def test_dynamic_slice_pytree_matches_lax() -> None:
 
     tree = {"a": jnp.arange(10), "b": jnp.arange(10) * 2}
     start_index = 2
-    limit_index = 7
+    slice_size = 5
 
-    sliced = dynamic_slice_pytree(tree, start_index, limit_index)
+    sliced = dynamic_slice_pytree(tree, start_index, slice_size)
     expected = jax.tree_util.tree_map(
         partial(
             jax.lax.dynamic_slice_in_dim,
             start_index=start_index,
-            slice_size=limit_index - start_index,
+            slice_size=slice_size,
             axis=0,
         ),
         tree,


### PR DESCRIPTION
## Summary
- define an `InferenceMethod` protocol describing the call interface for inference routines
- update NUTS and particle MCMC functions to follow the unified call signature
- re-export the protocol from the package root
- fix `dynamic_slice_pytree` and adjust util tests
- update tests for the new call patterns
- clarify protocol documentation and simplify interface

## Testing
- `ruff check seqjax/inference/interface.py`
- `mypy seqjax/inference/interface.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d4fa8ba88325b01c08c8fd8e1937