### PR TITLE
Add latent inference protocol

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -15,7 +15,7 @@ from .inference.particlefilter import Proposal
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
 from .inference.mcmc import NUTSConfig, run_nuts, run_bayesian_nuts
-from .inference.interface import InferenceMethod
+from .inference.interface import InferenceMethod, LatentInferenceMethod
 from .inference import (
     BufferedConfig,
     run_buffered_filter,
@@ -39,6 +39,7 @@ __all__ = [
     "run_nuts",
     "run_bayesian_nuts",
     "InferenceMethod",
+    "LatentInferenceMethod",
     "BufferedConfig",
     "run_buffered_filter",
     "BufferedSGLDConfig",

--- a/seqjax/inference/__init__.py
+++ b/seqjax/inference/__init__.py
@@ -1,4 +1,4 @@
-from .interface import InferenceMethod
+from .interface import InferenceMethod, LatentInferenceMethod
 from .buffered import (
     BufferedConfig,
     run_buffered_filter,
@@ -8,6 +8,7 @@ from .buffered import (
 
 __all__ = [
     "InferenceMethod",
+    "LatentInferenceMethod",
     "BufferedConfig",
     "run_buffered_filter",
     "BufferedSGLDConfig",

--- a/seqjax/inference/interface.py
+++ b/seqjax/inference/interface.py
@@ -41,3 +41,29 @@ class InferenceMethod(Protocol):
         initial_conditions: tuple[ConditionType, ...] | None = None,
         observation_history: tuple[ObservationType, ...] | None = None,
     ) -> Any: ...
+
+
+class LatentInferenceMethod(Protocol):
+    """Callable protocol for latent path inference routines.
+
+    This interface covers samplers that condition on known model parameters and
+    return samples from the posterior ``p(x | y, \theta)``. Concrete inference
+    functions such as :func:`~seqjax.inference.mcmc.run_nuts` should be
+    partially applied with any algorithm-specific configuration before being
+    used through this protocol.
+    """
+
+    def __call__(
+        self,
+        target: SequentialModel[
+            ParticleType, ObservationType, ConditionType, ParametersType
+        ],
+        key: PRNGKeyArray,
+        observations: Batched[ObservationType, SequenceAxis],
+        *,
+        parameters: ParametersType,
+        condition_path: Batched[ConditionType, SequenceAxis] | None = None,
+        initial_latents: Batched[ParticleType, SequenceAxis] | None = None,
+        initial_conditions: tuple[ConditionType, ...] | None = None,
+        observation_history: tuple[ObservationType, ...] | None = None,
+    ) -> Any: ...


### PR DESCRIPTION
## Summary
- add `LatentInferenceMethod` protocol describing inference of p(x|y,theta)
- export new protocol from package init files

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_6866e2b78ccc8325b4fb1eac530185a3