### PR TITLE
Add Kalman filter

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -23,6 +23,7 @@ from .inference import (
     run_buffered_sgld,
 )
 from .inference.pmcmc import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
+from .inference.kalman import run_kalman_filter
 
 __all__ = [
     "simulate",
@@ -46,4 +47,5 @@ __all__ = [
     "RandomWalkConfig",
     "ParticleMCMCConfig",
     "run_particle_mcmc",
+    "run_kalman_filter",
 ]

--- a/seqjax/inference/kalman.py
+++ b/seqjax/inference/kalman.py
@@ -1,0 +1,59 @@
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+
+from seqjax.model.linear_gaussian import LGSSMParameters, VectorObservation
+
+
+def _gaussian_logpdf(x: Array, mean: Array, cov: Array) -> Array:
+    dim = x.shape[0]
+    diff = x - mean
+    solve = jnp.linalg.solve(cov, diff)
+    log_det = jnp.linalg.slogdet(cov)[1]
+    return -0.5 * (dim * jnp.log(2.0 * jnp.pi) + log_det + diff @ solve)
+
+
+def run_kalman_filter(
+    parameters: LGSSMParameters,
+    observations: VectorObservation,
+    *,
+    initial_mean: Array | None = None,
+    initial_cov: Array | None = None,
+) -> tuple[Array, Array, Array]:
+    """Run a Kalman filtering pass for a linear Gaussian state space model."""
+
+    A = parameters.transition_matrix
+    C = parameters.emission_matrix
+    Q = jnp.diag(parameters.transition_noise_scale ** 2)
+    R = jnp.diag(parameters.emission_noise_scale ** 2)
+
+    state_dim = A.shape[0]
+    if initial_mean is None:
+        initial_mean = jnp.zeros(state_dim)
+    if initial_cov is None:
+        initial_cov = Q
+
+    y = observations.y
+
+    def step(carry, obs):
+        mean_prev, cov_prev, log_like_prev = carry
+        mean_pred = A @ mean_prev
+        cov_pred = A @ cov_prev @ A.T + Q
+
+        innov = obs - C @ mean_pred
+        S = C @ cov_pred @ C.T + R
+        K = jnp.linalg.solve(S, cov_pred @ C.T).T
+
+        mean = mean_pred + K @ innov
+        cov = cov_pred - K @ C @ cov_pred
+
+        log_like = log_like_prev + _gaussian_logpdf(obs, C @ mean_pred, S)
+
+        return (mean, cov, log_like), (mean, cov, log_like)
+
+    _, hist = jax.lax.scan(
+        step, (initial_mean, initial_cov, jnp.array(0.0)), y
+    )
+
+    means, covs, log_marginal = hist
+    return means, covs, log_marginal

--- a/tests/test_kalman.py
+++ b/tests/test_kalman.py
@@ -1,0 +1,40 @@
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.inference.kalman import run_kalman_filter
+from seqjax.inference.particlefilter import (
+    BootstrapParticleFilter,
+    run_filter,
+    current_particle_mean,
+    current_particle_variance,
+)
+from seqjax import simulate
+from seqjax.model.linear_gaussian import LinearGaussianSSM, LGSSMParameters
+
+
+def test_kalman_filter_matches_particle_filter() -> None:
+    seq_len = 6
+    key = jrandom.PRNGKey(0)
+    target = LinearGaussianSSM()
+    params = LGSSMParameters()
+    _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
+
+    pf = BootstrapParticleFilter(target, num_particles=1000)
+    mean_rec = current_particle_mean(lambda p: p.x)
+    var_rec = current_particle_variance(lambda p: p.x)
+    log_w, _, _, _, (mean_hist, var_hist) = run_filter(
+        pf,
+        jrandom.PRNGKey(1),
+        params,
+        obs,
+        initial_conditions=(None,),
+        recorders=(mean_rec, var_rec),
+    )
+
+    kf_mean, kf_cov, _ = run_kalman_filter(params, obs)
+
+    assert kf_mean.shape == mean_hist.shape
+    assert kf_cov.shape[:2] == (seq_len, params.transition_matrix.shape[0])
+    assert jnp.allclose(kf_mean, mean_hist, atol=1e-1, rtol=1e-1)
+    assert jnp.allclose(jnp.diagonal(kf_cov, axis1=1, axis2=2), var_hist, atol=1e-1, rtol=1e-1)


### PR DESCRIPTION
## Summary
- implement a basic Kalman filter for linear Gaussian SSMs
- re-export `run_kalman_filter` from package root
- test that Kalman filter mean and variance match a bootstrap particle filter

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_6866e2acf26c8325b3c1342d8a5b35a5