### PR TITLE
Add new particle filter resamplers

### DIFF
--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -9,6 +9,9 @@ from .filter_definitions import BootstrapParticleFilter, AuxiliaryParticleFilter
 from .resampling import (
     Resampler,
     gumbel_resample_from_log_weights,
+    multinomial_resample_from_log_weights,
+    stratified_resample_from_log_weights,
+    systematic_resample_from_log_weights,
     conditional_resample,
 )
 from .metrics import compute_esse_from_log_weights
@@ -26,6 +29,9 @@ __all__ = [
     "vmapped_run_filter",
     "Resampler",
     "gumbel_resample_from_log_weights",
+    "multinomial_resample_from_log_weights",
+    "stratified_resample_from_log_weights",
+    "systematic_resample_from_log_weights",
     "conditional_resample",
     "compute_esse_from_log_weights",
     "BootstrapParticleFilter",

--- a/seqjax/inference/particlefilter/resampling.py
+++ b/seqjax/inference/particlefilter/resampling.py
@@ -34,6 +34,69 @@ def gumbel_resample_from_log_weights(
     return resampled_particles, new_log_weights
 
 
+def multinomial_resample_from_log_weights(
+    key: PRNGKeyArray,
+    log_weights: Array,
+    particles: tuple[ParticleType, ...],
+    _ess_e: Scalar,
+) -> tuple[tuple[ParticleType, ...], Array]:
+    """Resample particles using standard multinomial sampling."""
+    particle_ix = jrandom.categorical(
+        key, log_weights, shape=(log_weights.shape[0],)
+    )
+    resampled_particles = jax.vmap(index_tree, in_axes=[None, 0, None])(
+        particles,
+        particle_ix,  # type: ignore[arg-type]
+        0,
+    )
+    new_log_weights = jnp.full_like(log_weights, -jnp.log(log_weights.shape[0]))
+    return resampled_particles, new_log_weights
+
+
+def stratified_resample_from_log_weights(
+    key: PRNGKeyArray,
+    log_weights: Array,
+    particles: tuple[ParticleType, ...],
+    _ess_e: Scalar,
+) -> tuple[tuple[ParticleType, ...], Array]:
+    """Resample particles using stratified resampling."""
+    weights = jax.nn.softmax(log_weights)
+    n = weights.shape[0]
+    u = jrandom.uniform(key, shape=(n,))
+    positions = (jnp.arange(n) + u) / n
+    cumulative = jnp.cumsum(weights)
+    particle_ix = jnp.searchsorted(cumulative, positions, side="right")
+    resampled_particles = jax.vmap(index_tree, in_axes=[None, 0, None])(
+        particles,
+        particle_ix,  # type: ignore[arg-type]
+        0,
+    )
+    new_log_weights = jnp.full_like(log_weights, -jnp.log(n))
+    return resampled_particles, new_log_weights
+
+
+def systematic_resample_from_log_weights(
+    key: PRNGKeyArray,
+    log_weights: Array,
+    particles: tuple[ParticleType, ...],
+    _ess_e: Scalar,
+) -> tuple[tuple[ParticleType, ...], Array]:
+    """Resample particles using systematic resampling."""
+    weights = jax.nn.softmax(log_weights)
+    n = weights.shape[0]
+    u0 = jrandom.uniform(key, minval=0.0, maxval=1.0 / n)
+    positions = u0 + jnp.arange(n) / n
+    cumulative = jnp.cumsum(weights)
+    particle_ix = jnp.searchsorted(cumulative, positions, side="right")
+    resampled_particles = jax.vmap(index_tree, in_axes=[None, 0, None])(
+        particles,
+        particle_ix,  # type: ignore[arg-type]
+        0,
+    )
+    new_log_weights = jnp.full_like(log_weights, -jnp.log(n))
+    return resampled_particles, new_log_weights
+
+
 def conditional_resample(
     key: PRNGKeyArray,
     log_weights: Array,


### PR DESCRIPTION
## Summary
- implement multinomial, stratified, and systematic resamplers
- export the new functions from the particle filter module
- test statistical correctness of all resampling methods

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_68678f95974c83259789fe272e5b6cf7