### PR TITLE
Support custom MCMC kernels in particle MCMC

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -14,7 +14,12 @@ from .inference.particlefilter import Proposal
 
 # simple inference utilities
 from .inference.particlefilter import BootstrapParticleFilter, AuxiliaryParticleFilter
-from .inference.mcmc import NUTSConfig, run_nuts, run_bayesian_nuts
+from .inference.mcmc import (
+    NUTSConfig,
+    run_nuts,
+    run_bayesian_nuts,
+    run_nuts_parameters,
+)
 from .inference.interface import InferenceMethod, LatentInferenceMethod
 from .inference import (
     BufferedConfig,
@@ -39,6 +44,7 @@ __all__ = [
     "NUTSConfig",
     "run_nuts",
     "run_bayesian_nuts",
+    "run_nuts_parameters",
     "InferenceMethod",
     "LatentInferenceMethod",
     "BufferedConfig",

--- a/seqjax/inference/buffered/sgmcmc.py
+++ b/seqjax/inference/buffered/sgmcmc.py
@@ -15,7 +15,7 @@ from seqjax.model.base import (
     ParameterPrior,
     HyperParametersType,
 )
-from seqjax.model.typing import Batched, SequenceAxis
+from seqjax.model.typing import Batched, SequenceAxis, SampleAxis
 from seqjax.inference.particlefilter import SMCSampler
 from .buffered import _run_segment
 
@@ -53,7 +53,7 @@ def run_buffered_sgld(
     *,
     condition_path: Batched[ConditionType, SequenceAxis] | None = None,
     config: BufferedSGLDConfig,
-) -> Batched[ParametersType, SequenceAxis | int]:
+) -> Batched[ParametersType, SampleAxis | int]:
     """Run buffered SGLD updates over ``observations``."""
 
     smc = config.particle_filter

--- a/seqjax/inference/mcmc/__init__.py
+++ b/seqjax/inference/mcmc/__init__.py
@@ -1,10 +1,11 @@
-from .nuts import NUTSConfig, run_nuts, run_bayesian_nuts
+from .nuts import NUTSConfig, run_nuts, run_bayesian_nuts, run_nuts_parameters
 from .metropolis import RandomWalkConfig, run_random_walk_metropolis
 
 __all__ = [
     "NUTSConfig",
     "run_nuts",
     "run_bayesian_nuts",
+    "run_nuts_parameters",
     "RandomWalkConfig",
     "run_random_walk_metropolis",
 ]

--- a/seqjax/model/typing.py
+++ b/seqjax/model/typing.py
@@ -70,6 +70,7 @@ HyperParametersType = TypeVar("HyperParametersType", bound=HyperParameters)
 
 Batch = TypeVarTuple("Batch")
 SequenceAxis = TypeVar("SequenceAxis", covariant=True)
+SampleAxis = TypeVar("SampleAxis", covariant=True)
 T_co = TypeVar("T_co", covariant=True)
 
 
@@ -77,8 +78,10 @@ class Batched(Protocol, Generic[T_co, Unpack[Batch], SequenceAxis]):
     """A :class:`~jaxtyping.PyTree` with arbitrary leading batch axes.
 
     ``Batch`` represents the shared leading dimensions while ``SequenceAxis``
-    denotes the trailing sequence length. Multiple return values can reuse the
-    same ``Batch`` tuple to indicate they are batched together.
+    denotes the trailing sequence length. ``SampleAxis`` can be used to
+    represent batches of independent samples that are not part of the
+    sequence dimension. Multiple return values can reuse the same ``Batch``
+    tuple to indicate they are batched together.
     """
 
 

--- a/tests/test_pmcmc.py
+++ b/tests/test_pmcmc.py
@@ -1,11 +1,13 @@
 import jax.random as jrandom
 import jax.numpy as jnp
 
+from functools import partial
+
 from seqjax.inference.pmcmc import (
-    RandomWalkConfig,
     ParticleMCMCConfig,
     run_particle_mcmc,
 )
+from seqjax.inference.mcmc import RandomWalkConfig, run_random_walk_metropolis, NUTSConfig, run_nuts_parameters
 from seqjax.inference.particlefilter import BootstrapParticleFilter
 from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
 from seqjax import simulate
@@ -20,8 +22,10 @@ def test_run_particle_mcmc_shape() -> None:
     )
 
     pf = BootstrapParticleFilter(target, num_particles=5)
+    rw_cfg = RandomWalkConfig(step_size=0.1, num_samples=3)
+    mcmc = partial(run_random_walk_metropolis, config=rw_cfg)
     config = ParticleMCMCConfig(
-        mcmc=RandomWalkConfig(step_size=0.1, num_samples=3),
+        mcmc=mcmc,
         particle_filter=pf,
     )
     sample_key = jrandom.PRNGKey(1)
@@ -35,7 +39,7 @@ def test_run_particle_mcmc_shape() -> None:
         initial_conditions=(None,),
     )
 
-    assert samples.ar.shape == (config.mcmc.num_samples,)
+    assert samples.ar.shape == (rw_cfg.num_samples,)
 
 
 def test_run_particle_mcmc_recovers_params() -> None:
@@ -51,8 +55,10 @@ def test_run_particle_mcmc_recovers_params() -> None:
     )
 
     pf = BootstrapParticleFilter(target, num_particles=10)
+    rw_cfg = RandomWalkConfig(step_size=0.05, num_samples=20)
+    mcmc = partial(run_random_walk_metropolis, config=rw_cfg)
     config = ParticleMCMCConfig(
-        mcmc=RandomWalkConfig(step_size=0.05, num_samples=20),
+        mcmc=mcmc,
         particle_filter=pf,
     )
     sample_key = jrandom.PRNGKey(1)
@@ -68,3 +74,33 @@ def test_run_particle_mcmc_recovers_params() -> None:
 
     mean_ar = jnp.mean(samples.ar)
     assert jnp.allclose(mean_ar, true_params.ar, atol=0.1)
+
+
+def test_particle_mcmc_with_nuts() -> None:
+    key = jrandom.PRNGKey(0)
+    target = AR1Target()
+    parameters = ARParameters()
+    _, observations, _, _ = simulate.simulate(
+        key, target, None, parameters, sequence_length=5
+    )
+
+    pf = BootstrapParticleFilter(target, num_particles=5)
+    nuts_cfg = NUTSConfig(num_warmup=5, num_samples=3, step_size=0.1)
+    mcmc = partial(run_nuts_parameters, config=nuts_cfg)
+    config = ParticleMCMCConfig(
+        mcmc=mcmc,
+        particle_filter=pf,
+    )
+    sample_key = jrandom.PRNGKey(1)
+    samples = run_particle_mcmc(
+        target,
+        sample_key,
+        observations,
+        parameter_prior=HalfCauchyStds(),
+        config=config,
+        initial_parameters=parameters,
+        initial_conditions=(None,),
+    )
+
+    assert samples.ar.shape == (nuts_cfg.num_samples,)
+


### PR DESCRIPTION
## Summary
- allow `run_particle_mcmc` to accept any parameter sampler
- add `run_nuts_parameters` helper and export it
- expose the new helper at the package root
- update tests to use partial kernels and ensure NUTS also works
- distinguish MCMC sample axis from the sequence axis

## Testing
- `pip install .[dev]`
- `mypy seqjax`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868ceda36c88325bf9fc352060e9cdd