### PR TITLE
Add SGLD inference utilities

### DIFF
--- a/seqjax/__init__.py
+++ b/seqjax/__init__.py
@@ -26,6 +26,8 @@ from .inference import (
     run_buffered_filter,
     BufferedSGLDConfig,
     run_buffered_sgld,
+    SGLDConfig,
+    run_sgld,
 )
 from .inference.pmcmc import RandomWalkConfig, ParticleMCMCConfig, run_particle_mcmc
 from .inference.kalman import run_kalman_filter
@@ -51,6 +53,8 @@ __all__ = [
     "run_buffered_filter",
     "BufferedSGLDConfig",
     "run_buffered_sgld",
+    "SGLDConfig",
+    "run_sgld",
     "RandomWalkConfig",
     "ParticleMCMCConfig",
     "run_particle_mcmc",

--- a/seqjax/inference/__init__.py
+++ b/seqjax/inference/__init__.py
@@ -5,6 +5,7 @@ from .buffered import (
     BufferedSGLDConfig,
     run_buffered_sgld,
 )
+from .sgld import SGLDConfig, run_sgld
 
 __all__ = [
     "InferenceMethod",
@@ -13,6 +14,8 @@ __all__ = [
     "run_buffered_filter",
     "BufferedSGLDConfig",
     "run_buffered_sgld",
+    "SGLDConfig",
+    "run_sgld",
 ]
 from .autoregressive_vi import (
     AutoregressiveSampler,

--- a/seqjax/inference/buffered/sgmcmc.py
+++ b/seqjax/inference/buffered/sgmcmc.py
@@ -18,13 +18,12 @@ from seqjax.model.base import (
 from seqjax.model.typing import Batched, SequenceAxis, SampleAxis
 from seqjax.inference.particlefilter import SMCSampler
 from .buffered import _run_segment
+from ..sgld import SGLDConfig, run_sgld
 
 
 class BufferedSGLDConfig(eqx.Module):
     """Configuration for :func:`run_buffered_sgld`."""
 
-    step_size: float | ParametersType = 1e-3
-    num_iters: int = 100
     buffer_size: int = 0
     batch_size: int = 1
     particle_filter: (
@@ -34,13 +33,51 @@ class BufferedSGLDConfig(eqx.Module):
     hyperparameters: HyperParametersType | None = None
 
 
-def _tree_randn_like(key: PRNGKeyArray, tree: ParametersType) -> ParametersType:
-    leaves, treedef = jax.tree_util.tree_flatten(tree)
-    keys = jrandom.split(key, len(leaves))
-    new_leaves = [
-        jrandom.normal(k, shape=jnp.shape(leaf)) for k, leaf in zip(keys, leaves)
-    ]
-    return jax.tree_util.tree_unflatten(treedef, new_leaves)
+def _make_grad_estimator(
+    target: SequentialModel[
+        ParticleType, ObservationType, ConditionType, ParametersType
+    ],
+    observations: Batched[ObservationType, SequenceAxis],
+    condition_path: Batched[ConditionType, SequenceAxis] | None,
+    config: BufferedSGLDConfig,
+) -> tuple[Callable[[ParametersType, PRNGKeyArray], ParametersType], int]:
+    """Return gradient estimator and maximum start index."""
+
+    smc = config.particle_filter
+    if smc is None:
+        raise ValueError("particle_filter must be provided in config")
+    if smc.target is not target:
+        smc = eqx.tree_at(lambda m: m.target, smc, target)
+
+    prior = config.parameter_prior
+    if prior is None:
+        raise ValueError("parameter_prior must be provided in config")
+
+    seq_len = jax.tree_util.tree_leaves(observations)[0].shape[0]
+    if config.batch_size > seq_len:
+        raise ValueError("batch_size must not exceed sequence length")
+
+    start_max = seq_len - config.batch_size + 1
+
+    def log_post(params: ParametersType, start: jax.Array, pf_key: PRNGKeyArray) -> jax.Array:
+        log_mps = _run_segment(
+            start,
+            smc,
+            pf_key,
+            params,
+            observations,
+            condition_path,
+            buffer_size=config.buffer_size,
+            batch_size=config.batch_size,
+        )
+        return prior.log_prob(params, config.hyperparameters) + jnp.sum(log_mps)
+
+    def grad_estimator(params: ParametersType, key: PRNGKeyArray) -> ParametersType:
+        start_key, pf_key = jrandom.split(key)
+        start = jrandom.randint(start_key, (), 0, start_max)
+        return jax.grad(lambda p: log_post(p, start, pf_key))(params)
+
+    return grad_estimator, start_max
 
 
 def run_buffered_sgld(
@@ -53,65 +90,11 @@ def run_buffered_sgld(
     *,
     condition_path: Batched[ConditionType, SequenceAxis] | None = None,
     config: BufferedSGLDConfig,
+    sgld_config: SGLDConfig = SGLDConfig(),
 ) -> Batched[ParametersType, SampleAxis | int]:
     """Run buffered SGLD updates over ``observations``."""
 
-    smc = config.particle_filter
-    if smc is None:
-        raise ValueError("particle_filter must be provided in config")
-    if smc.target is not target:
-        smc = eqx.tree_at(lambda m: m.target, smc, target)
-    prior = config.parameter_prior
-    if prior is None:
-        raise ValueError("parameter_prior must be provided in config")
-
-    seq_len = jax.tree_util.tree_leaves(observations)[0].shape[0]
-    if config.batch_size > seq_len:
-        raise ValueError("batch_size must not exceed sequence length")
-
-    start_max = seq_len - config.batch_size + 1
-    n_iters = config.num_iters
-    split_keys = jrandom.split(key, 2 * n_iters + 1)
-    start_key, pf_keys, noise_keys = (
-        split_keys[0],
-        split_keys[1 : n_iters + 1],
-        split_keys[n_iters + 1 :],
+    grad_estimator, _ = _make_grad_estimator(
+        target, observations, condition_path, config
     )
-    starts = jrandom.randint(start_key, shape=(n_iters,), minval=0, maxval=start_max)
-
-    if jax.tree_util.tree_structure(config.step_size) == jax.tree_util.tree_structure(
-        parameters
-    ):  # type: ignore[operator]
-        step_sizes = config.step_size
-    else:
-        step_sizes = jax.tree_util.tree_map(lambda _: config.step_size, parameters)
-
-    def step(params: ParametersType, inp: tuple[PRNGKeyArray, PRNGKeyArray, jax.Array]):
-        pf_key, noise_key, start = inp
-
-        def log_post(p: ParametersType) -> jax.Array:
-            log_mps = _run_segment(
-                start,
-                smc,
-                pf_key,
-                p,
-                observations,
-                condition_path,
-                buffer_size=config.buffer_size,
-                batch_size=config.batch_size,
-            )
-            return prior.log_prob(p, config.hyperparameters) + jnp.sum(log_mps)
-
-        grad = jax.grad(log_post)(params)
-        noise = _tree_randn_like(noise_key, params)
-        updates = jax.tree_util.tree_map(
-            lambda g, n, s: 0.5 * s * g + jnp.sqrt(s) * n,
-            grad,
-            noise,
-            step_sizes,
-        )
-        params = eqx.apply_updates(params, updates)
-        return params, params
-
-    _, samples = jax.lax.scan(step, parameters, (pf_keys, noise_keys, starts))
-    return samples
+    return run_sgld(grad_estimator, key, parameters, config=sgld_config)

--- a/seqjax/inference/sgld.py
+++ b/seqjax/inference/sgld.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+from jaxtyping import PRNGKeyArray
+from typing import Callable
+
+from seqjax.model.base import ParametersType
+from seqjax.model.typing import Batched, SampleAxis
+from typing import Generic
+
+
+class SGLDConfig(eqx.Module, Generic[ParametersType]):
+    """Configuration for :func:`run_sgld`."""
+
+    step_size: float | ParametersType = 1e-3
+    num_iters: int = 100
+
+
+def _tree_randn_like(key: PRNGKeyArray, tree: ParametersType) -> ParametersType:  # type: ignore[misc]
+    leaves, treedef = jax.tree_util.tree_flatten(tree)
+    keys = jrandom.split(key, len(leaves))
+    new_leaves = [jrandom.normal(k, shape=jnp.shape(leaf)) for k, leaf in zip(keys, leaves)]
+    return jax.tree_util.tree_unflatten(treedef, new_leaves)
+
+
+def run_sgld(
+    grad_estimator: Callable[[ParametersType, PRNGKeyArray], ParametersType],
+    key: PRNGKeyArray,
+    initial_parameters: ParametersType,
+    *,
+    config: SGLDConfig = SGLDConfig(),
+) -> Batched[ParametersType, SampleAxis | int]:
+    """Run SGLD updates using ``grad_estimator``."""
+
+    n_iters = config.num_iters
+    split_keys = jrandom.split(key, 2 * n_iters)
+    grad_keys = split_keys[:n_iters]
+    noise_keys = split_keys[n_iters:]
+
+    if jax.tree_util.tree_structure(config.step_size) == jax.tree_util.tree_structure(initial_parameters):  # type: ignore[operator]
+        step_sizes = config.step_size
+    else:
+        step_sizes = jax.tree_util.tree_map(lambda _: config.step_size, initial_parameters)
+
+    def step(params: ParametersType, inp: tuple[PRNGKeyArray, PRNGKeyArray]):
+        g_key, n_key = inp
+        grad = grad_estimator(params, g_key)
+        noise = _tree_randn_like(n_key, params)
+        updates = jax.tree_util.tree_map(
+            lambda g, n, s: 0.5 * s * g + jnp.sqrt(s) * n,
+            grad,
+            noise,
+            step_sizes,
+        )
+        params = eqx.apply_updates(params, updates)
+        return params, params
+
+    _, samples = jax.lax.scan(step, initial_parameters, (grad_keys, noise_keys))
+    return samples

--- a/tests/test_buffered_sgld.py
+++ b/tests/test_buffered_sgld.py
@@ -3,6 +3,7 @@ import jax.random as jrandom
 from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
 from seqjax import simulate, BootstrapParticleFilter
 from seqjax.inference.buffered import BufferedSGLDConfig, run_buffered_sgld
+from seqjax.inference.sgld import SGLDConfig
 
 
 def test_buffered_sgld_runs() -> None:
@@ -14,16 +15,17 @@ def test_buffered_sgld_runs() -> None:
 
     pf = BootstrapParticleFilter(target, num_particles=4)
     config = BufferedSGLDConfig(
-        step_size=0.1,
-        num_iters=3,
         buffer_size=1,
         batch_size=2,
         particle_filter=pf,
         parameter_prior=prior,
     )
-    samples = run_buffered_sgld(target, jrandom.PRNGKey(1), params, obs, config=config)
+    sgld_config = SGLDConfig(step_size=0.1, num_iters=3)
+    samples = run_buffered_sgld(
+        target, jrandom.PRNGKey(1), params, obs, config=config, sgld_config=sgld_config
+    )
 
-    assert samples.ar.shape == (config.num_iters,)
+    assert samples.ar.shape == (sgld_config.num_iters,)
 
 def test_buffered_sgld_step_tree() -> None:
     key = jrandom.PRNGKey(0)
@@ -35,13 +37,14 @@ def test_buffered_sgld_step_tree() -> None:
     pf = BootstrapParticleFilter(target, num_particles=4)
     step_sizes = ARParameters(ar=0.1, observation_std=0.0, transition_std=0.0)
     config = BufferedSGLDConfig(
-        step_size=step_sizes,
-        num_iters=3,
         buffer_size=1,
         batch_size=2,
         particle_filter=pf,
         parameter_prior=prior,
     )
-    samples = run_buffered_sgld(target, jrandom.PRNGKey(1), params, obs, config=config)
+    sgld_config = SGLDConfig(step_size=step_sizes, num_iters=3)
+    samples = run_buffered_sgld(
+        target, jrandom.PRNGKey(1), params, obs, config=config, sgld_config=sgld_config
+    )
 
     assert (samples.observation_std == params.observation_std).all()

--- a/tests/test_sgld.py
+++ b/tests/test_sgld.py
@@ -1,0 +1,22 @@
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.inference.sgld import SGLDConfig, run_sgld
+from seqjax.model.ar import ARParameters
+
+
+def dummy_grad(params: ARParameters, key: jrandom.PRNGKey) -> ARParameters:
+    del key
+    return ARParameters(
+        ar=jnp.ones_like(params.ar),
+        observation_std=jnp.zeros_like(params.observation_std),
+        transition_std=jnp.zeros_like(params.transition_std),
+    )
+
+
+def test_run_sgld_basic() -> None:
+    params = ARParameters()
+    cfg = SGLDConfig(step_size=0.1, num_iters=4)
+    samples = run_sgld(dummy_grad, jrandom.PRNGKey(0), params, config=cfg)
+    assert samples.ar.shape == (cfg.num_iters,)
+


### PR DESCRIPTION
## Summary
- implement general SGLD update loop
- refactor buffered SGLD to reuse the new implementation
- expose SGLD helpers in inference modules
- adjust tests and add direct SGLD test

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`

------
https://chatgpt.com/codex/tasks/task_e_686a31153ba483259ac790656c02533a