### PR TITLE
Switch stochastic vol obs to returns

### DIFF
--- a/experiments/stochastic_vol/skew_exploration.py
+++ b/experiments/stochastic_vol/skew_exploration.py
@@ -20,18 +20,19 @@ def simulate_path(skew: float, steps: int = 10000, seed: int = 0):
     )
 
     dt = jnp.array(1.0 / (256 * 8))
-    cond = TimeIncrement(dt * jnp.ones(steps))
+    target = SkewStochasticVol()
+    cond = TimeIncrement(dt * jnp.ones(steps + target.prior.order - 1))
 
     key = jrandom.key(seed)
     latent, obs, *_ = simulate.simulate(
         key,
-        SkewStochasticVol,
+        target,
         cond,
         params,
         sequence_length=steps,
     )
 
-    returns = jnp.log(obs.underlying[1:]) - jnp.log(obs.underlying[:-1])
+    returns = obs.log_return
     realised_vol = jnp.sqrt(jnp.mean(returns**2) / dt)
     return returns, realised_vol
 

--- a/tests/test_filters_integration.py
+++ b/tests/test_filters_integration.py
@@ -10,7 +10,7 @@ from seqjax.model.stochastic_vol import (
     SimpleStochasticVol,
     LogVolRW,
     TimeIncrement,
-    Underlying,
+    LogReturnObs,
 )
 from seqjax.model.poisson_ssm import PoissonSSM, PoissonSSMParameters
 
@@ -44,7 +44,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
         long_term_vol=jnp.array(1.0),
     )
     full_cond = TimeIncrement(jnp.ones(seq_len + sv_target.prior.order - 1))
-    _, sv_obs, _, y_hist = simulate.simulate(
+    _, sv_obs, _, _ = simulate.simulate(
         key, sv_target, full_cond, sv_params, sequence_length=seq_len
     )
     sv_pf = filter_cls(sv_target, num_particles=5)
@@ -57,7 +57,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
         initial_conditions=tuple(
             TimeIncrement(full_cond.dt[i]) for i in range(sv_target.prior.order)
         ),
-        observation_history=(Underlying(y_hist.underlying[0]),)
+        observation_history=()
     )
     assert log_w.shape == (sv_pf.num_particles,)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,9 +80,9 @@ def test_simple_stochastic_vol_simulate_length() -> None:
     )
 
     assert latent.log_vol.shape == (3,)
-    assert obs.underlying.shape == (3,)
-    assert pytree_shape(x_hist)[0][0] == 1
-    assert pytree_shape(y_hist)[0][0] == 1
+    assert obs.log_return.shape == (3,)
+    assert pytree_shape(x_hist)[0][0] == 0
+    assert pytree_shape(y_hist)[0][0] == 0
 
 
 def test_sir_simulate_length() -> None:


### PR DESCRIPTION
## Summary
- add `TwoStepGaussianStart` prior for skewed volatility models
- update stochastic volatility experiments for log return observations
- skew model now uses the new prior

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_686a36af038883258b819469785cac27