### PR TITLE
Add ancestor indexing in particle filter

### DIFF
--- a/experiments/smc/logistic_regression.py
+++ b/experiments/smc/logistic_regression.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     mean_rec = current_particle_mean(lambda p: p.theta)
     quant_rec = current_particle_quantiles(lambda p: p.theta, quantiles=(0.05, 0.95))
 
-    log_w, particles, _, ess, (theta_mean, theta_quant) = run_filter(
+    log_w, particles, _, ess, _, (theta_mean, theta_quant) = run_filter(
         pf,
         jrandom.key(1),
         data,

--- a/experiments/stochastic_vol/bootstrap_filter.py
+++ b/experiments/stochastic_vol/bootstrap_filter.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     init_conds = tuple(TimeIncrement(cond.dt[i]) for i in range(2))
     cond_path = TimeIncrement(cond.dt[2:])
 
-    log_w, _, log_mp, ess, (filt_lv,filt_quant) = run_filter(
+    log_w, _, log_mp, ess, _, (filt_lv,filt_quant) = run_filter(
         bpf,
         filter_key,
         params,

--- a/experiments/stochastic_vol/unbiased_marginal.py
+++ b/experiments/stochastic_vol/unbiased_marginal.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
             cond_path,
         )
 
-        _, _, log_mp, _, _ = vmapped_run_filter(
+        _, _, log_mp, _, _, _ = vmapped_run_filter(
             bpf,
             filter_keys,
             batched_params,

--- a/seqjax/inference/buffered/buffered.py
+++ b/seqjax/inference/buffered/buffered.py
@@ -78,7 +78,7 @@ def _run_segment(
     else:
         init_conds = ()
 
-    _, _, log_mp_hist, _, _ = run_filter(
+    _, _, log_mp_hist, _, _, _ = run_filter(
         smc,
         key,
         parameters,

--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -93,8 +93,16 @@ def proposal_from_transition(
 
 class Recorder(Protocol):
     def __call__(
-        self, weights: Array, particles: tuple[ParticleType, ...]
-    ) -> PyTree: ...
+        self,
+        weights: Array,
+        particles: tuple[ParticleType, ...],
+        ancestors: Array,
+        observation: ObservationType,
+        condition: ConditionType,
+        last_particles: tuple[ParticleType, ...],
+        last_log_weights: Array,
+    ) -> PyTree:
+        ...
 
 
 class SMCSampler(
@@ -151,7 +159,13 @@ class SMCSampler(
         observation: ObservationType,
         condition: ConditionType,
         params: ParametersType,
-    ) -> tuple[Array, tuple[ParticleType, ...], tuple[ObservationType, ...], Scalar]:
+    ) -> tuple[
+        Array,
+        tuple[ParticleType, ...],
+        tuple[ObservationType, ...],
+        Scalar,
+        Array,
+    ]:
         """Advance the filter by one step and maintain particle history."""
 
         resample_key, proposal_key = jrandom.split(step_key)
@@ -168,7 +182,9 @@ class SMCSampler(
         ess_e = compute_esse_from_log_weights(log_w_resample)
 
 
-        particles, log_w = self.resampler(resample_key, log_w, particles, ess_e)
+        particles, log_w, ancestor_ix = self.resampler(
+            resample_key, log_w, particles, ess_e
+        )
 
         proposal_history = particles[-self.proposal.order :]
         transition_history = particles[-self.target.transition.order :]
@@ -219,7 +235,7 @@ class SMCSampler(
         else:
             observation_history = ()
 
-        return log_w, particles, observation_history, ess_e
+        return log_w, particles, observation_history, ess_e, ancestor_ix
 
 
 def run_filter(
@@ -235,6 +251,7 @@ def run_filter(
 ) -> tuple[
     Array,
     tuple[ParticleType, ...],
+    Array,
     Array,
     Array,
     tuple[PyTree, ...],
@@ -270,7 +287,9 @@ def run_filter(
     def body(state, inputs):
         step_key, observation, condition = inputs
         log_w, particles, obs_hist, log_mp_prev = state
-        log_w, particles, obs_hist, ess_e = smc.sample_step(
+        last_particles = particles
+        last_log_w = log_w
+        log_w, particles, obs_hist, ess_e, ancestor_ix = smc.sample_step(
             step_key,
             log_w,
             particles,
@@ -284,11 +303,32 @@ def run_filter(
         log_w = log_w - log_sum_w
         weights = jax.nn.softmax(log_w)
         recorder_vals = (
-            tuple(r(weights, particles) for r in recorders)
+            tuple(
+                r(
+                    weights,
+                    particles,
+                    ancestor_ix,
+                    observation,
+                    condition,
+                    last_particles,
+                    last_log_w,
+                )
+                for r in recorders
+            )
             if recorders is not None
             else ()
         )
-        return (log_w, particles, obs_hist, log_mp), (log_mp, ess_e, *recorder_vals)
+        return (
+            log_w,
+            particles,
+            obs_hist,
+            log_mp,
+        ), (
+            log_mp,
+            ess_e,
+            ancestor_ix,
+            *recorder_vals,
+        )
 
     if condition_path is None:
         cond_seq: Any = [None] * sequence_length
@@ -305,13 +345,15 @@ def run_filter(
 
     log_marginal_history = scan_hist[0]
     ess_history = scan_hist[1]
-    recorder_history = tuple(scan_hist[2:])
+    ancestor_history = scan_hist[2]
+    recorder_history = tuple(scan_hist[3:])
 
     return (
         log_weights,
         particles,
         log_marginal_history,
         ess_history,
+        ancestor_history,
         recorder_history,
     )
 
@@ -329,6 +371,7 @@ def vmapped_run_filter(
 ) -> tuple[
     Array,
     tuple[ParticleType, ...],
+    Array,
     Array,
     Array,
     tuple[PyTree, ...],

--- a/seqjax/inference/pmcmc/pmmh.py
+++ b/seqjax/inference/pmcmc/pmmh.py
@@ -55,7 +55,7 @@ def _log_density(
     initial_conditions: tuple[ConditionType, ...] | None,
     observation_history: tuple[ObservationType, ...] | None,
 ) -> jnp.ndarray:
-    _, _, log_mp, _, _ = run_filter(
+    _, _, log_mp, _, _, _ = run_filter(
         pf,
         key,
         params,

--- a/tests/test_filters_integration.py
+++ b/tests/test_filters_integration.py
@@ -26,7 +26,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
     _, ar_obs, _, _ = simulate.simulate(key, ar_target, None, ar_params, sequence_length=seq_len)
     filter_key = jrandom.PRNGKey(1)
     ar_pf = filter_cls(ar_target, num_particles=5)
-    log_w, _, _, _, _ = run_filter(
+    log_w, _, _, _, _, _ = run_filter(
         ar_pf,
         filter_key,
         ar_params,
@@ -48,7 +48,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
         key, sv_target, full_cond, sv_params, sequence_length=seq_len
     )
     sv_pf = filter_cls(sv_target, num_particles=5)
-    log_w, _, _, _, _ = run_filter(
+    log_w, _, _, _, _, _ = run_filter(
         sv_pf,
         jrandom.PRNGKey(3),
         sv_params,
@@ -71,7 +71,7 @@ def test_filters_linear_gaussian(filter_cls) -> None:
     params = LGSSMParameters()
     _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
     pf = filter_cls(target, num_particles=5)
-    log_w, _, _, _, _ = run_filter(
+    log_w, _, _, _, _, _ = run_filter(
         pf,
         jrandom.PRNGKey(5),
         params,
@@ -90,7 +90,7 @@ def test_filters_poisson_ssm(filter_cls) -> None:
     params = PoissonSSMParameters()
     _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
     pf = filter_cls(target, num_particles=5)
-    log_w, _, _, _, _ = run_filter(
+    log_w, _, _, _, _, _ = run_filter(
         pf,
         jrandom.PRNGKey(7),
         params,

--- a/tests/test_kalman.py
+++ b/tests/test_kalman.py
@@ -23,7 +23,7 @@ def test_kalman_filter_matches_particle_filter() -> None:
     pf = BootstrapParticleFilter(target, num_particles=1000)
     mean_rec = current_particle_mean(lambda p: p.x)
     var_rec = current_particle_variance(lambda p: p.x)
-    log_w, _, _, _, (mean_hist, var_hist) = run_filter(
+    log_w, _, _, _, _, (mean_hist, var_hist) = run_filter(
         pf,
         jrandom.PRNGKey(1),
         params,

--- a/tests/test_logistic_smc.py
+++ b/tests/test_logistic_smc.py
@@ -27,7 +27,7 @@ def test_logistic_smc_runs() -> None:
 
     model = LogisticRegressionSMC()
     pf = BootstrapParticleFilter(model, num_particles=20)
-    log_w, particles, log_mp, ess, _ = run_filter(
+    log_w, particles, log_mp, ess, anc, _ = run_filter(
         pf,
         jrandom.PRNGKey(1),
         data,
@@ -40,3 +40,4 @@ def test_logistic_smc_runs() -> None:
     seq_len = betas.shape[0] - 1
     assert log_mp.shape[0] == seq_len
     assert ess.shape[0] == seq_len
+    assert anc.shape == (seq_len, pf.num_particles)

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -24,7 +24,7 @@ def test_ar1_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, particles, log_mp, ess, rec = run_filter(
+    log_w, particles, log_mp, ess, anc, rec = run_filter(
         bpf,
         filter_key,
         parameters,
@@ -36,6 +36,7 @@ def test_ar1_bootstrap_filter_runs() -> None:
     assert log_mp.shape == (observations.y.shape[0],)
     assert ess.shape == (observations.y.shape[0],)
     assert rec == ()
+    assert anc.shape == (observations.y.shape[0], bpf.num_particles)
 
 
 def test_run_filter_requires_initial_conditions() -> None:
@@ -67,7 +68,7 @@ def test_particle_recorders_shapes() -> None:
     quant_rec = current_particle_quantiles(lambda p: p.x)
     var_rec = current_particle_variance(lambda p: p.x)
 
-    log_w, _, _, _, (quant_hist, var_hist) = run_filter(
+    log_w, _, _, _, _, (quant_hist, var_hist) = run_filter(
         bpf,
         filter_key,
         parameters,
@@ -91,7 +92,7 @@ def test_ar1_auxiliary_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     apf = AuxiliaryParticleFilter(target, num_particles=10)
-    log_w, particles, log_mp, ess, _ = run_filter(
+    log_w, particles, log_mp, ess, anc, _ = run_filter(
         apf,
         filter_key,
         parameters,
@@ -101,6 +102,7 @@ def test_ar1_auxiliary_filter_runs() -> None:
 
     assert log_w.shape == (apf.num_particles,)
     assert ess.shape == (observations.y.shape[0],)
+    assert anc.shape == (observations.y.shape[0], apf.num_particles)
 
 
 def test_sir_bootstrap_filter_runs() -> None:
@@ -117,7 +119,7 @@ def test_sir_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, _, _, ess, _ = run_filter(
+    log_w, _, _, ess, anc, _ = run_filter(
         bpf,
         filter_key,
         parameters,
@@ -127,6 +129,7 @@ def test_sir_bootstrap_filter_runs() -> None:
 
     assert log_w.shape == (bpf.num_particles,)
     assert ess.shape == (observations.new_cases.shape[0],)
+    assert anc.shape == (observations.new_cases.shape[0], bpf.num_particles)
 
 
 def test_vmapped_run_filter_shapes() -> None:
@@ -152,7 +155,7 @@ def test_vmapped_run_filter_shapes() -> None:
         observations,
     )
 
-    log_w, _, log_mp, _, _ = vmapped_run_filter(
+    log_w, _, log_mp, _, _, _ = vmapped_run_filter(
         bpf,
         keys,
         batched_params,


### PR DESCRIPTION
## Summary
- return ancestor indices from `SMCSampler.sample_step`
- propagate ancestor index history from `run_filter`
- adapt resamplers to output indices
- extend recorders to accept ancestor indices
- update experiments and pmcmc
- adjust tests for new outputs
- **extend recorder interface with observation, condition, previous particles and weights**

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_686a38342b808325acdc426b5f7fef16