### PR TITLE
Compute log marginal in recorder

### DIFF
--- a/experiments/smc/logistic_regression.py
+++ b/experiments/smc/logistic_regression.py
@@ -8,6 +8,8 @@ from seqjax.inference.particlefilter import (
     current_particle_mean,
     current_particle_quantiles,
     run_filter,
+    log_marginal,
+    effective_sample_size,
 )
 from seqjax.model.logistic_smc import (
     LogisticRegressionSMC,
@@ -41,14 +43,16 @@ if __name__ == "__main__":
     mean_rec = current_particle_mean(lambda p: p.theta)
     quant_rec = current_particle_quantiles(lambda p: p.theta, quantiles=(0.05, 0.95))
 
-    log_w, particles, _, ess, _, (theta_mean, theta_quant) = run_filter(
+    lm_rec = log_marginal()
+    ess_rec = effective_sample_size()
+    log_w, particles, _, (log_mp, ess, theta_mean, theta_quant) = run_filter(
         pf,
         jrandom.key(1),
         data,
         obs_path,
         cond_path,
         initial_conditions=init_cond,
-        recorders=(mean_rec, quant_rec),
+        recorders=(lm_rec, ess_rec, mean_rec, quant_rec),
     )
 
     weights = jax.nn.softmax(log_w)

--- a/experiments/stochastic_vol/bootstrap_filter.py
+++ b/experiments/stochastic_vol/bootstrap_filter.py
@@ -12,6 +12,8 @@ from seqjax.inference.particlefilter import (
     BootstrapParticleFilter,
     current_particle_quantiles,
     run_filter,
+    log_marginal,
+    effective_sample_size,
 )
 
 
@@ -50,7 +52,9 @@ if __name__ == "__main__":
     init_conds = tuple(TimeIncrement(cond.dt[i]) for i in range(target.prior.order))
     cond_path = TimeIncrement(cond.dt[target.prior.order:])
 
-    log_w, _, log_mp, ess, _, (filt_lv,filt_quant) = run_filter(
+    lm_rec = log_marginal()
+    ess_rec = effective_sample_size()
+    log_w, _, _, (log_mp, ess, filt_lv, filt_quant) = run_filter(
         bpf,
         filter_key,
         params,
@@ -58,7 +62,7 @@ if __name__ == "__main__":
         cond_path,
         initial_conditions=init_conds,
         observation_history=(),
-        recorders=(mean_log_vol, quant_rec),
+        recorders=(lm_rec, ess_rec, mean_log_vol, quant_rec),
     )
 
     t = jnp.arange(filt_lv.shape[0])

--- a/seqjax/inference/buffered/buffered.py
+++ b/seqjax/inference/buffered/buffered.py
@@ -18,7 +18,7 @@ from seqjax.util import (
     dynamic_index_pytree_in_dim,
     dynamic_slice_pytree,
 )
-from seqjax.inference.particlefilter import SMCSampler, run_filter
+from seqjax.inference.particlefilter import SMCSampler, run_filter, log_marginal
 
 
 def _pad_edges_pytree(tree: Any, pad: int) -> Any:
@@ -78,15 +78,18 @@ def _run_segment(
     else:
         init_conds = ()
 
-    _, _, log_mp_hist, _, _, _ = run_filter(
+    lm_rec = log_marginal()
+    _, _, _, (log_mp_hist,) = run_filter(
         smc,
         key,
         parameters,
         obs_slice,
         cond_slice,
         initial_conditions=init_conds,
+        recorders=(lm_rec,),
     )
 
+    log_mp_hist = jnp.cumsum(log_mp_hist)
     return log_mp_hist[buffer_size : buffer_size + batch_size]
 
 

--- a/seqjax/inference/particlefilter/__init__.py
+++ b/seqjax/inference/particlefilter/__init__.py
@@ -19,6 +19,8 @@ from .recorders import (
     current_particle_mean,
     current_particle_quantiles,
     current_particle_variance,
+    log_marginal,
+    effective_sample_size,
 )
 
 __all__ = [
@@ -39,4 +41,6 @@ __all__ = [
     "current_particle_mean",
     "current_particle_quantiles",
     "current_particle_variance",
+    "log_marginal",
+    "effective_sample_size",
 ]

--- a/tests/test_filters_integration.py
+++ b/tests/test_filters_integration.py
@@ -26,7 +26,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
     _, ar_obs, _, _ = simulate.simulate(key, ar_target, None, ar_params, sequence_length=seq_len)
     filter_key = jrandom.PRNGKey(1)
     ar_pf = filter_cls(ar_target, num_particles=5)
-    log_w, _, _, _, _, _ = run_filter(
+    log_w, _, _, _ = run_filter(
         ar_pf,
         filter_key,
         ar_params,
@@ -48,7 +48,7 @@ def test_filters_ar1_and_stochastic_vol(filter_cls) -> None:
         key, sv_target, full_cond, sv_params, sequence_length=seq_len
     )
     sv_pf = filter_cls(sv_target, num_particles=5)
-    log_w, _, _, _, _, _ = run_filter(
+    log_w, _, _, _ = run_filter(
         sv_pf,
         jrandom.PRNGKey(3),
         sv_params,
@@ -71,7 +71,7 @@ def test_filters_linear_gaussian(filter_cls) -> None:
     params = LGSSMParameters()
     _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
     pf = filter_cls(target, num_particles=5)
-    log_w, _, _, _, _, _ = run_filter(
+    log_w, _, _, _ = run_filter(
         pf,
         jrandom.PRNGKey(5),
         params,
@@ -90,7 +90,7 @@ def test_filters_poisson_ssm(filter_cls) -> None:
     params = PoissonSSMParameters()
     _, obs, _, _ = simulate.simulate(key, target, None, params, sequence_length=seq_len)
     pf = filter_cls(target, num_particles=5)
-    log_w, _, _, _, _, _ = run_filter(
+    log_w, _, _, _ = run_filter(
         pf,
         jrandom.PRNGKey(7),
         params,

--- a/tests/test_kalman.py
+++ b/tests/test_kalman.py
@@ -23,7 +23,7 @@ def test_kalman_filter_matches_particle_filter() -> None:
     pf = BootstrapParticleFilter(target, num_particles=1000)
     mean_rec = current_particle_mean(lambda p: p.x)
     var_rec = current_particle_variance(lambda p: p.x)
-    log_w, _, _, _, _, (mean_hist, var_hist) = run_filter(
+    log_w, _, anc, (mean_hist, var_hist) = run_filter(
         pf,
         jrandom.PRNGKey(1),
         params,

--- a/tests/test_logistic_smc.py
+++ b/tests/test_logistic_smc.py
@@ -2,7 +2,12 @@ import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 
-from seqjax.inference.particlefilter import BootstrapParticleFilter, run_filter
+from seqjax.inference.particlefilter import (
+    BootstrapParticleFilter,
+    run_filter,
+    log_marginal,
+    effective_sample_size,
+)
 from seqjax.model.logistic_smc import (
     LogisticRegressionSMC,
     LogRegData,
@@ -27,13 +32,16 @@ def test_logistic_smc_runs() -> None:
 
     model = LogisticRegressionSMC()
     pf = BootstrapParticleFilter(model, num_particles=20)
-    log_w, particles, log_mp, ess, anc, _ = run_filter(
+    lm_rec = log_marginal()
+    ess_rec = effective_sample_size()
+    log_w, particles, anc, (log_mp, ess) = run_filter(
         pf,
         jrandom.PRNGKey(1),
         data,
         observation_path=obs_path,
         condition_path=cond_path,
         initial_conditions=(AnnealCondition(beta=betas[0], beta_prev=betas[0]),),
+        recorders=(lm_rec, ess_rec),
     )
 
     assert log_w.shape == (pf.num_particles,)

--- a/tests/test_particlefilter.py
+++ b/tests/test_particlefilter.py
@@ -11,6 +11,8 @@ from seqjax.inference.particlefilter import (
     vmapped_run_filter,
     current_particle_quantiles,
     current_particle_variance,
+    log_marginal,
+    effective_sample_size,
 )
 
 
@@ -24,18 +26,20 @@ def test_ar1_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, particles, log_mp, ess, anc, rec = run_filter(
+    lm_rec = log_marginal()
+    ess_rec = effective_sample_size()
+    log_w, particles, anc, (log_mp, ess) = run_filter(
         bpf,
         filter_key,
         parameters,
         observations,
         initial_conditions=(None,),
+        recorders=(lm_rec, ess_rec),
     )
 
     assert log_w.shape == (bpf.num_particles,)
     assert log_mp.shape == (observations.y.shape[0],)
     assert ess.shape == (observations.y.shape[0],)
-    assert rec == ()
     assert anc.shape == (observations.y.shape[0], bpf.num_particles)
 
 
@@ -68,7 +72,7 @@ def test_particle_recorders_shapes() -> None:
     quant_rec = current_particle_quantiles(lambda p: p.x)
     var_rec = current_particle_variance(lambda p: p.x)
 
-    log_w, _, _, _, _, (quant_hist, var_hist) = run_filter(
+    log_w, _, _, (quant_hist, var_hist) = run_filter(
         bpf,
         filter_key,
         parameters,
@@ -92,12 +96,15 @@ def test_ar1_auxiliary_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     apf = AuxiliaryParticleFilter(target, num_particles=10)
-    log_w, particles, log_mp, ess, anc, _ = run_filter(
+    lm_rec = log_marginal()
+    ess_rec = effective_sample_size()
+    log_w, particles, anc, (log_mp, ess) = run_filter(
         apf,
         filter_key,
         parameters,
         observations,
         initial_conditions=(None,),
+        recorders=(lm_rec, ess_rec),
     )
 
     assert log_w.shape == (apf.num_particles,)
@@ -119,12 +126,14 @@ def test_sir_bootstrap_filter_runs() -> None:
     )
     filter_key = jrandom.PRNGKey(1)
     bpf = BootstrapParticleFilter(target, num_particles=10)
-    log_w, _, _, ess, anc, _ = run_filter(
+    ess_rec = effective_sample_size()
+    log_w, _, anc, (ess,) = run_filter(
         bpf,
         filter_key,
         parameters,
         observations,
         initial_conditions=(None,),
+        recorders=(ess_rec,),
     )
 
     assert log_w.shape == (bpf.num_particles,)
@@ -155,12 +164,14 @@ def test_vmapped_run_filter_shapes() -> None:
         observations,
     )
 
-    log_w, _, log_mp, _, _, _ = vmapped_run_filter(
+    lm_rec = log_marginal()
+    log_w, _, anc, (log_mp,) = vmapped_run_filter(
         bpf,
         keys,
         batched_params,
         batched_obs,
         initial_conditions=(None,),
+        recorders=(lm_rec,),
     )
 
     assert log_w.shape == (batch, bpf.num_particles)

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -75,9 +75,39 @@ def test_particle_recorders_correctness() -> None:
     ancestors = jnp.arange(particles[0].shape[0])
     obs = jnp.array(0.0)
     cond = jnp.array(0.0)
-    mean = mean_rec(weights, particles, ancestors, obs, cond, particles, jnp.log(weights))
-    quant = quant_rec(weights, particles, ancestors, obs, cond, particles, jnp.log(weights))
-    var = var_rec(weights, particles, ancestors, obs, cond, particles, jnp.log(weights))
+    mean = mean_rec(
+        weights,
+        particles,
+        ancestors,
+        obs,
+        cond,
+        particles,
+        jnp.log(weights),
+        jnp.array(0.0),
+        jnp.array(0.0),
+    )
+    quant = quant_rec(
+        weights,
+        particles,
+        ancestors,
+        obs,
+        cond,
+        particles,
+        jnp.log(weights),
+        jnp.array(0.0),
+        jnp.array(0.0),
+    )
+    var = var_rec(
+        weights,
+        particles,
+        ancestors,
+        obs,
+        cond,
+        particles,
+        jnp.log(weights),
+        jnp.array(0.0),
+        jnp.array(0.0),
+    )
 
     exp_mean = jnp.sum(weights * particles[0])
     exp_quant = jnp.array([2.0])


### PR DESCRIPTION
## Summary
- move log marginal computation from `run_filter` to recorder
- simplify particle filter loop and expose log weight sum to recorders
- accumulate log marginal outside buffered and PMCMC utilities
- type hint recorder factory return values with `Recorder`

## Testing
- `pip install .[dev]`
- `pytest -q`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_686b7231f36883259f078e11e82290e2