### PR TITLE
Improve model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,19 @@ print(observation_path)
 ```
 
 SeqJAX will check at runtime that `AR1Target` and its components implement the required interface. When extending the library, these checks help catch mistakes such as missing `sample` or `log_prob` implementations.
+
+## Documentation
+
+The library's API reference can be built using [MkDocs](https://www.mkdocs.org/) together with the [mkdocstrings](https://mkdocstrings.github.io/) plugin. After installing the optional dependencies
+
+```bash
+pip install mkdocs mkdocstrings[python]
+```
+
+add ``mkdocstrings`` to your ``mkdocs.yml`` and include objects with the ``:::`` syntax:
+
+```markdown
+::: seqjax.model.LinearGaussianSSM
+```
+
+Run ``mkdocs serve`` to preview the documentation locally or ``mkdocs build`` to generate a site.

--- a/seqjax/model/__init__.py
+++ b/seqjax/model/__init__.py
@@ -1,4 +1,14 @@
-"""Convenience re-exports for model components."""
+"""Public API for the :mod:`seqjax.model` package.
+
+This module re-exports the most commonly used classes so that projects can
+import them directly from :mod:`seqjax.model`.
+
+Example
+-------
+>>> from seqjax.model import LinearGaussianSSM, LGSSMParameters
+>>> model = LinearGaussianSSM()
+>>> params = LGSSMParameters()
+"""
 
 from seqjax.model.base import SequentialModel
 from seqjax.model.visualise import graph_model

--- a/seqjax/model/ar.py
+++ b/seqjax/model/ar.py
@@ -1,4 +1,13 @@
-"""AR(1) example model implementations."""
+"""AR(1) example model implementations.
+
+The :class:`AR1Target` demonstrates a minimal autoregressive model.
+
+Example
+-------
+>>> from seqjax.model.ar import AR1Target, ARParameters
+>>> model = AR1Target()
+>>> params = ARParameters()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/base.py
+++ b/seqjax/model/base.py
@@ -1,11 +1,14 @@
-"""Abstract base classes for sequential models.
+"""Base interfaces for constructing sequential probabilistic models.
 
-Condition and Parameters are separated. Parameters remain static over time while
-conditions vary.
+These definitions separate ``Condition`` (time varying) from ``Parameters``
+(static) and group the pure functions operating on ``Particle`` objects into
+``Prior``, ``Transition`` and ``Emission`` components.
 
-Use ``SequentialModel`` to group pure functions that operate on the same
-``Particle`` and ``Emission`` types. ``Prior``, ``Transition`` and ``Emission``
-provide additional structure and are typically paired in use.
+Example
+-------
+>>> from seqjax.model.base import SequentialModel
+>>> class MyModel(SequentialModel):
+...     pass
 """
 
 from abc import abstractmethod

--- a/seqjax/model/evaluate.py
+++ b/seqjax/model/evaluate.py
@@ -1,4 +1,13 @@
-"""Model evaluation utilities for computing log probabilities."""
+"""Model evaluation utilities for computing log probabilities.
+
+These helper functions operate on any
+:class:`~seqjax.model.base.SequentialModel`.
+
+Example
+-------
+>>> from seqjax.model.evaluate import log_prob_joint
+>>> log_prob_joint(model, observations, conditions, params)
+"""
 
 import jax
 from jaxtyping import Scalar

--- a/seqjax/model/hmm.py
+++ b/seqjax/model/hmm.py
@@ -1,4 +1,13 @@
-"""Discrete Hidden Markov Model components."""
+"""Discrete Hidden Markov Model components.
+
+This module implements a tiny categorical HMM suitable for demonstrations.
+
+Example
+-------
+>>> from seqjax.model.hmm import HiddenMarkovModel, HMMParameters
+>>> model = HiddenMarkovModel()
+>>> params = HMMParameters()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/linear_gaussian.py
+++ b/seqjax/model/linear_gaussian.py
@@ -1,4 +1,16 @@
-"""Multidimensional linear Gaussian state space model."""
+"""Multidimensional linear Gaussian state space model.
+
+The classes defined here implement a simple linear Gaussian state space model
+useful for demonstrations and testing.  The implementation mirrors the
+``Kalman`` filter setup and can be simulated using
+:func:`seqjax.model.simulate.simulate`.
+
+Example
+-------
+>>> from seqjax.model.linear_gaussian import LinearGaussianSSM, LGSSMParameters
+>>> model = LinearGaussianSSM()
+>>> params = LGSSMParameters()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/logistic_smc.py
+++ b/seqjax/model/logistic_smc.py
@@ -1,4 +1,13 @@
-"""Logistic regression SMC sampler example."""
+"""Logistic regression SMC sampler example.
+
+This module shows how an annealed sequential Monte Carlo sampler can be built
+using the :class:`~seqjax.model.base.SequentialModel` interfaces.
+
+Example
+-------
+>>> from seqjax.model.logistic_smc import LogisticRegressionSMC
+>>> smc = LogisticRegressionSMC()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/poisson_ssm.py
+++ b/seqjax/model/poisson_ssm.py
@@ -1,4 +1,14 @@
-"""Simple Poisson state space model."""
+"""Simple Poisson state space model.
+
+The :class:`PoissonSSM` defined here is a minimal example of a non-Gaussian
+state space model.
+
+Example
+-------
+>>> from seqjax.model.poisson_ssm import PoissonSSM, PoissonSSMParameters
+>>> model = PoissonSSM()
+>>> params = PoissonSSMParameters()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/simulate.py
+++ b/seqjax/model/simulate.py
@@ -1,4 +1,12 @@
-"""Utilities for simulating sequences from a target model."""
+"""Utilities for simulating sequences from a target model.
+
+Use :func:`simulate` to generate example data from any
+:class:`~seqjax.model.base.SequentialModel`.
+
+Example
+-------
+>>> simulate.simulate(key, model, condition, parameters, sequence_length=10)
+"""
 
 from functools import partial
 

--- a/seqjax/model/sir.py
+++ b/seqjax/model/sir.py
@@ -1,4 +1,14 @@
-"""Simple stochastic SIR model."""
+"""Simple stochastic SIR model.
+
+The components in this module define a discrete time susceptible--infected--
+recovered (SIR) process.
+
+Example
+-------
+>>> from seqjax.model.sir import SIRModel, SIRParameters
+>>> model = SIRModel()
+>>> params = SIRParameters()
+"""
 
 from dataclasses import field
 from typing import ClassVar

--- a/seqjax/model/stochastic_vol.py
+++ b/seqjax/model/stochastic_vol.py
@@ -1,4 +1,15 @@
-"""Stochastic volatility models."""
+"""Stochastic volatility models.
+
+This module includes a simple log-volatility random walk and related emission
+models.  The :class:`SimpleStochasticVol` and :class:`SkewStochasticVol` classes
+are provided for experimentation.
+
+Example
+-------
+>>> from seqjax.model.stochastic_vol import SimpleStochasticVol, SVParameters
+>>> model = SimpleStochasticVol()
+>>> params = SVParameters()
+"""
 
 from dataclasses import dataclass, field
 from typing import ClassVar, Literal, Union

--- a/seqjax/model/typing.py
+++ b/seqjax/model/typing.py
@@ -1,4 +1,13 @@
-"""Runtime type checking utilities for model interfaces."""
+"""Runtime type checking utilities for model interfaces.
+
+The helpers in this module enforce that subclasses implement the required
+methods with matching signatures.
+
+Example
+-------
+>>> class MyParticle(Particle):
+...     value: int
+"""
 
 import inspect
 from typing import Generic, Protocol, TypeVar, TypeVarTuple, Unpack

--- a/seqjax/model/visualise.py
+++ b/seqjax/model/visualise.py
@@ -1,4 +1,13 @@
-"""Graphviz based visualisation utilities for sequential models."""
+"""Graphviz based visualisation utilities for sequential models.
+
+The :func:`graph_model` helper produces a :class:`graphviz.Digraph` describing
+the dependencies in a :class:`~seqjax.model.base.SequentialModel`.
+
+Example
+-------
+>>> from seqjax.model.visualise import graph_model
+>>> dot = graph_model(my_model)
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- expand file headers with more detailed docstrings
- provide usage examples for each model module
- document how to build API docs with MkDocs in README

## Testing
- `pytest -q`
- `python -m mypy seqjax` *(failed: environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_686e4112b6b083258a48d1c650183885