### PR TITLE
Update AR1 Bayesian NUTS test

### DIFF
--- a/tests/test_mcmc_bayesian.py
+++ b/tests/test_mcmc_bayesian.py
@@ -1,6 +1,7 @@
 import jax.random as jrandom
 
-from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax.model.ar import AR1Target, ARParameters, AR1Bayesian
+from seqjax.model.typing import HyperParameters
 from seqjax.model import simulate
 from seqjax.inference.mcmc import NUTSConfig, run_bayesian_nuts
 
@@ -9,21 +10,20 @@ def test_run_bayesian_nuts_shape() -> None:
     key = jrandom.PRNGKey(0)
     target = AR1Target()
     parameters = ARParameters()
-    latents, observations, _, _ = simulate.simulate(
+    latents_true, observations, _, _ = simulate.simulate(
         key, target, None, parameters, sequence_length=5
     )
 
     config = NUTSConfig(num_warmup=5, num_samples=3, step_size=0.1)
     sample_key = jrandom.PRNGKey(1)
-    samples_latents, samples_params = run_bayesian_nuts(
-        target,
+    posterior = AR1Bayesian(parameters)
+    time_array, latents, params, _ = run_bayesian_nuts(
+        posterior,
+        HyperParameters(),
         sample_key,
         observations,
-        parameter_prior=HalfCauchyStds(),
-        initial_latents=latents,
-        initial_parameters=parameters,
         config=config,
     )
 
-    assert samples_latents.x.shape == (config.num_samples, latents.x.shape[0])
-    assert samples_params.ar.shape == (config.num_samples,)
+    assert latents.x.shape == (time_array.shape[0], latents_true.x.shape[0])
+    assert params.ar.shape == (time_array.shape[0],)


### PR DESCRIPTION
## Summary
- adapt Bayesian NUTS test to new AR1Bayesian interface
- construct posterior and run sampler without explicit initial values

## Testing
- `pip install .[dev]`
- `pytest` *(fails: ModuleNotFoundError for BootstrapParticleFilter and other components)*
- `mypy seqjax` *(fails: many type annotation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e6b6c7a48325a3f7d65f27d69192