### PR TITLE
Refactor PMCMC tests for new API

### DIFF
--- a/tests/test_pmcmc.py
+++ b/tests/test_pmcmc.py
@@ -1,15 +1,11 @@
-import jax.random as jrandom
 import jax.numpy as jnp
+import jax.random as jrandom
 
-from functools import partial
-
-from seqjax.inference.pmcmc import (
-    ParticleMCMCConfig,
-    run_particle_mcmc,
-)
-from seqjax.inference.mcmc import RandomWalkConfig, run_random_walk_metropolis, NUTSConfig, run_nuts_parameters
+from seqjax.inference.pmcmc import ParticleMCMCConfig, run_particle_mcmc
+from seqjax.inference.mcmc import RandomWalkConfig
 from seqjax.inference.particlefilter import BootstrapParticleFilter
-from seqjax.model.ar import AR1Target, ARParameters, HalfCauchyStds
+from seqjax.model.ar import AR1Target, ARParameters, AR1Bayesian
+from seqjax.model.typing import HyperParameters
 from seqjax import simulate
 
 
@@ -23,20 +19,17 @@ def test_run_particle_mcmc_shape() -> None:
 
     pf = BootstrapParticleFilter(target, num_particles=5)
     rw_cfg = RandomWalkConfig(step_size=0.1, num_samples=3)
-    mcmc = partial(run_random_walk_metropolis, config=rw_cfg)
-    config = ParticleMCMCConfig(
-        mcmc=mcmc,
-        particle_filter=pf,
-    )
+    config = ParticleMCMCConfig(mcmc=rw_cfg, particle_filter=pf)
     sample_key = jrandom.PRNGKey(1)
-    samples = run_particle_mcmc(
-        target,
+    posterior = AR1Bayesian(parameters)
+
+    time_array, _, samples, _ = run_particle_mcmc(
+        posterior,
+        HyperParameters(),
         sample_key,
         observations,
-        parameter_prior=HalfCauchyStds(),
-        config=config,
-        initial_parameters=parameters,
-        initial_conditions=(None,),
+        None,
+        config,
     )
 
     assert samples.ar.shape == (rw_cfg.num_samples,)
@@ -56,51 +49,18 @@ def test_run_particle_mcmc_recovers_params() -> None:
 
     pf = BootstrapParticleFilter(target, num_particles=10)
     rw_cfg = RandomWalkConfig(step_size=0.05, num_samples=20)
-    mcmc = partial(run_random_walk_metropolis, config=rw_cfg)
-    config = ParticleMCMCConfig(
-        mcmc=mcmc,
-        particle_filter=pf,
-    )
+    config = ParticleMCMCConfig(mcmc=rw_cfg, particle_filter=pf)
     sample_key = jrandom.PRNGKey(1)
-    samples = run_particle_mcmc(
-        target,
+    posterior = AR1Bayesian(true_params)
+
+    time_array, _, samples, _ = run_particle_mcmc(
+        posterior,
+        HyperParameters(),
         sample_key,
         observations,
-        parameter_prior=HalfCauchyStds(),
-        config=config,
-        initial_parameters=true_params,
-        initial_conditions=(None,),
+        None,
+        config,
     )
 
     mean_ar = jnp.mean(samples.ar)
     assert jnp.allclose(mean_ar, true_params.ar, atol=0.1)
-
-
-def test_particle_mcmc_with_nuts() -> None:
-    key = jrandom.PRNGKey(0)
-    target = AR1Target()
-    parameters = ARParameters()
-    _, observations, _, _ = simulate.simulate(
-        key, target, None, parameters, sequence_length=5
-    )
-
-    pf = BootstrapParticleFilter(target, num_particles=5)
-    nuts_cfg = NUTSConfig(num_warmup=5, num_samples=3, step_size=0.1)
-    mcmc = partial(run_nuts_parameters, config=nuts_cfg)
-    config = ParticleMCMCConfig(
-        mcmc=mcmc,
-        particle_filter=pf,
-    )
-    sample_key = jrandom.PRNGKey(1)
-    samples = run_particle_mcmc(
-        target,
-        sample_key,
-        observations,
-        parameter_prior=HalfCauchyStds(),
-        config=config,
-        initial_parameters=parameters,
-        initial_conditions=(None,),
-    )
-
-    assert samples.ar.shape == (nuts_cfg.num_samples,)
-


### PR DESCRIPTION
## Summary
- update particle MCMC tests for new `ParticleMCMCConfig` API
- remove legacy NUTS-based test

## Testing
- `pip install .[dev]`
- `pytest` *(fails: ImportError while collecting tests)*
- `mypy seqjax` *(fails: Need type annotation for "approximation" in seqjax/inference/vi/run.py:122)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e6bae59883259080027ce7e3328d