### PR TITLE
refactor particle filter recorders

### DIFF
--- a/experiments/smc/logistic_regression.py
+++ b/experiments/smc/logistic_regression.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import functools
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
@@ -40,12 +41,12 @@ if __name__ == "__main__":
     pf = BootstrapParticleFilter(model, num_particles=1000)
     init_cond = (AnnealCondition(beta=betas[0], beta_prev=betas[0]),)
 
-    mean_rec = current_particle_mean(lambda p: p.theta)
-    quant_rec = current_particle_quantiles(lambda p: p.theta, quantiles=(0.05, 0.95))
+    mean_rec = current_particle_mean
+    quant_rec = functools.partial(current_particle_quantiles, quantiles=(0.05, 0.95))
 
-    lm_rec = log_marginal()
-    ess_rec = effective_sample_size()
-    log_w, particles, _, (log_mp, ess, theta_mean, theta_quant) = run_filter(
+    lm_rec = log_marginal
+    ess_rec = effective_sample_size
+    log_w, particles, _, (log_mp, ess, mean_state, quant_state) = run_filter(
         pf,
         jrandom.key(1),
         data,
@@ -54,6 +55,9 @@ if __name__ == "__main__":
         initial_conditions=init_cond,
         recorders=(lm_rec, ess_rec, mean_rec, quant_rec),
     )
+
+    theta_mean = mean_state.theta
+    theta_quant = quant_state.theta
 
     weights = jax.nn.softmax(log_w)
     theta_samples = particles[-1].theta

--- a/experiments/stochastic_vol/unbiased_marginal.py
+++ b/experiments/stochastic_vol/unbiased_marginal.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
             cond_path,
         )
 
-        lm_rec = log_marginal()
+        lm_rec = log_marginal
         _, _, _, (log_mp,) = vmapped_run_filter(
             bpf,
             filter_keys,

--- a/seqjax/inference/pmcmc/pmmh.py
+++ b/seqjax/inference/pmcmc/pmmh.py
@@ -80,7 +80,7 @@ def run_particle_mcmc(
             key,
             model_params,
             observation_path,
-            recorders=(log_marginal(),),
+            recorders=(log_marginal,),
         )
         log_prior = target_posterior.parameter_prior.log_prob(params, hyperparameters)
         return jnp.sum(log_marginal_increments) + log_prior

--- a/seqjax/inference/sgld.py
+++ b/seqjax/inference/sgld.py
@@ -279,7 +279,7 @@ def run_full_sgld_mcmc(
             key,
             model_params,
             observation_path,
-            recorders=(log_marginal(),),
+            recorders=(log_marginal,),
             target_parameters=target_posterior.target_parameter,
         )
         log_prior = target_posterior.parameter_prior.log_prob(params, hyperparameters)
@@ -428,7 +428,7 @@ def run_buffer_sgld_mcmc(
             key,
             model_params,
             observation_path,
-            recorders=(log_marginal(),),
+            recorders=(log_marginal,),
             target_parameters=target_posterior.target_parameter,
         )
         log_prior = target_posterior.parameter_prior.log_prob(params, hyperparameters)

--- a/tests/inference/test_particle_filter.py
+++ b/tests/inference/test_particle_filter.py
@@ -38,13 +38,13 @@ def test_filtering_moments_close_to_kalman() -> None:
         params,
         obs,
         recorders=(
-            current_particle_mean(lambda p: p.x),
-            current_particle_variance(lambda p: p.x),
-            log_marginal(),
+            current_particle_mean,
+            current_particle_variance,
+            log_marginal,
         ),
     )
-    pf_means = jnp.squeeze(jnp.asarray(pf_means))
-    pf_vars = jnp.squeeze(jnp.asarray(pf_vars))
+    pf_means = jnp.squeeze(jnp.asarray(pf_means.x))
+    pf_vars = jnp.squeeze(jnp.asarray(pf_vars.x))
     kf_means = jnp.squeeze(kf_means, axis=-1)
     kf_vars = jnp.squeeze(kf_covs)
     mean_err = jnp.mean(jnp.abs(pf_means - kf_means))
@@ -69,7 +69,7 @@ def test_marginal_likelihood_unbiased() -> None:
             jrandom.fold_in(key, i),
             params,
             obs,
-            recorders=(log_marginal(),),
+            recorders=(log_marginal,),
         )
         pf_lls.append(jnp.sum(jnp.asarray(log_incs)))
     pf_lls = jnp.asarray(pf_lls, dtype=jnp.float64)
@@ -97,7 +97,7 @@ def test_incremental_normalizers() -> None:
     num_particles = 200
     pf = BootstrapParticleFilter(model, num_particles=num_particles)
     key = jrandom.PRNGKey(3)
-    _, _, (log_incs,) = run_filter(pf, key, params, obs, recorders=(log_marginal(),))
+    _, _, (log_incs,) = run_filter(pf, key, params, obs, recorders=(log_marginal,))
     log_incs = jnp.asarray(log_incs)
     total_from_prod = jnp.log(jnp.prod(jnp.exp(log_incs)))
     total_from_sum = jnp.sum(log_incs)


### PR DESCRIPTION
## Summary
- expose recorder utilities as direct callables taking `FilterData`
- update tests and examples to pass recorder functions directly

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax/inference/particlefilter/recorders.py`
- `mypy seqjax` *(fails: Too many values to unpack; incompatible types in various modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c418d7ec10832594360fff1e54d274