### PR TITLE
Improve typing for seqjax io metadata helpers

### DIFF
--- a/seqjax/io.py
+++ b/seqjax/io.py
@@ -1,7 +1,10 @@
-import polars as pl
+from collections.abc import Mapping
+from typing import Any
+
+import polars as pl  # type: ignore[import-not-found]
 import numpy as np
 from seqjax.model.typing import Packable
-import wandb
+import wandb  # type: ignore[import-not-found]
 import os
 from seqjax.model.registry import DataConfig
 from seqjax.model import simulate
@@ -10,8 +13,8 @@ import jax.random as jrandom
 SEQJAX_DATA_DIR = "../"
 
 
-def normalize_parquet_metadata(md: dict) -> dict[str, bytes]:
-    out = {}
+def normalize_parquet_metadata(md: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
     for k, v in md.items():
         if k == "elapsed_time_s":
             # this is not brilliant encoding, but the quantity does not
@@ -22,8 +25,8 @@ def normalize_parquet_metadata(md: dict) -> dict[str, bytes]:
     return out
 
 
-def process_parquet_metadata(md: dict) -> dict[str, bytes]:
-    out = {}
+def process_parquet_metadata(md: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
     for k, v in md.items():
         if k == "elapsed_time_s":
             out[k] = float(v)


### PR DESCRIPTION
## Summary
- tighten the parquet metadata helpers to use `Mapping[str, Any]` and explicit return types
- silence mypy missing stub errors for optional third-party dependencies
- remove the unnecessary postponed annotations import from `seqjax/io.py`

## Testing
- pip install .[dev]
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68cd2e21df1083259256a4365ef4d970