### PR TITLE
Update particle filter generics

### DIFF
--- a/seqjax/inference/particlefilter/base.py
+++ b/seqjax/inference/particlefilter/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Callable, Generic, Protocol
+from typing import Callable, Protocol, cast
 from abc import abstractmethod
 
 import equinox as eqx
@@ -9,41 +9,43 @@ import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 from jaxtyping import Array, PRNGKeyArray, PyTree, Scalar
-from seqjax.model.base import (
-    ConditionType,
-    ObservationType,
-    ParametersType,
-    ParticleType,
-    SequentialModel,
-    Transition,
-)
 import seqjax.model.typing as seqjtyping
+from seqjax.model.base import SequentialModel, Transition
 from seqjax import util
 from .resampling import Resampler
 from .metrics import compute_esse_from_log_weights
 
 
-class FilterData(eqx.Module):
+class FilterData[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](eqx.Module):
     """
     Encapsulates the data arising from a filter step
     """
 
     log_w: Array
-    particles: tuple[seqjtyping.Particle, ...]
+    particles: tuple[ParticleT, ...]
     ancestor_ix: Array
-    observation: seqjtyping.Observation
-    obs_hist: tuple[seqjtyping.Observation, ...]
-    condition: seqjtyping.Condition | None
+    observation: ObservationT
+    obs_hist: tuple[ObservationT, ...]
+    condition: ConditionT
     last_log_w: Array
-    last_particles: Array
+    last_particles: tuple[ParticleT, ...]
     ess_e: Array
     log_weight_increment: Array
-    parameters: seqjtyping.Parameters
+    parameters: ParametersT
 
 
-class Proposal(
+class Proposal[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](
     eqx.Module,
-    Generic[ParticleType, ObservationType, ConditionType, ParametersType],
     seqjtyping.EnforceInterface,
 ):
     """Proposal distribution for sequential importance sampling."""
@@ -54,84 +56,127 @@ class Proposal(
     @abstractmethod
     def sample(
         key: PRNGKeyArray,
-        particle_history: tuple[ParticleType, ...],
-        observation: ObservationType,
-        condition: ConditionType,
-        parameters: ParametersType,
-    ) -> ParticleType: ...
+        particle_history: tuple[ParticleT, ...],
+        observation: ObservationT,
+        condition: ConditionT,
+        parameters: ParametersT,
+    ) -> ParticleT: ...
 
     @staticmethod
     @abstractmethod
     def log_prob(
-        particle_history: tuple[ParticleType, ...],
-        observation: ObservationType,
-        particle: ParticleType,
-        condition: ConditionType,
-        parameters: ParametersType,
+        particle_history: tuple[ParticleT, ...],
+        observation: ObservationT,
+        particle: ParticleT,
+        condition: ConditionT,
+        parameters: ParametersT,
     ) -> Scalar: ...
 
 
-class TransitionProposal(
-    eqx.Module,
-    Generic[ParticleType, ObservationType, ConditionType, ParametersType],
-):
+class TransitionProposal[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](eqx.Module):
     """Adapter converting a ``Transition`` to a ``Proposal``."""
 
-    transition: Transition[ParticleType, ConditionType, ParametersType]
+    transition: Transition[
+        ParticleT,
+        tuple[ParticleT, ...],
+        ConditionT,
+        ParametersT,
+    ]
     order: int
-    target_parameters: Callable = lambda x: x
+    target_parameters: Callable[[ParametersT], ParametersT]
 
     def sample(
         self,
         key: PRNGKeyArray,
-        particle_history: tuple[ParticleType, ...],
-        observation: ObservationType,
-        condition: ConditionType,
-        parameters: ParametersType,
-    ) -> ParticleType:
+        particle_history: tuple[ParticleT, ...],
+        observation: ObservationT,
+        condition: ConditionT,
+        parameters: ParametersT,
+    ) -> ParticleT:
         return self.transition.sample(
             key, particle_history, condition, self.target_parameters(parameters)
         )
 
     def log_prob(
         self,
-        particle_history: tuple[ParticleType, ...],
-        observation: ObservationType,
-        particle: ParticleType,
-        condition: ConditionType,
-        parameters: ParametersType,
+        particle_history: tuple[ParticleT, ...],
+        observation: ObservationT,
+        particle: ParticleT,
+        condition: ConditionT,
+        parameters: ParametersT,
     ) -> Scalar:
         return self.transition.log_prob(
             particle_history, particle, condition, self.target_parameters(parameters)
         )
 
 
-def proposal_from_transition(
-    transition: Transition[ParticleType, ConditionType, ParametersType],
-    target_parameters: Callable = lambda x: x,
-) -> TransitionProposal[ParticleType, ObservationType, ConditionType, ParametersType]:
-    return TransitionProposal(
-        transition=transition,
-        order=transition.order,
-        target_parameters=target_parameters,
+def proposal_from_transition[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](
+    transition: Transition[
+        ParticleT,
+        tuple[ParticleT, ...],
+        ConditionT,
+        ParametersT,
+    ],
+    target_parameters: Callable[[ParametersT], ParametersT] | None = None,
+) -> Proposal[ParticleT, ObservationT, ConditionT, ParametersT]:
+    if target_parameters is None:
+        target_parameters = cast(Callable[[ParametersT], ParametersT], lambda x: x)
+    return cast(
+        Proposal[ParticleT, ObservationT, ConditionT, ParametersT],
+        TransitionProposal(
+            transition=transition,
+            order=transition.order,
+            target_parameters=target_parameters,
+        ),
     )
 
 
-class Recorder(Protocol):
-    def __call__(self, filter_data: FilterData) -> PyTree: ...
+class Recorder[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](Protocol):
+    def __call__(
+        self,
+        filter_data: FilterData[
+            ParticleT,
+            ObservationT,
+            ConditionT,
+            ParametersT,
+        ],
+    ) -> PyTree: ...
 
 
-class SMCSampler(
-    eqx.Module,
-    Generic[ParticleType, ObservationType, ConditionType, ParametersType],
-):
+class SMCSampler[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](eqx.Module):
     """Base class implementing sequential Monte Carlo."""
 
     target: SequentialModel[
-        ParticleType, ObservationType, ConditionType, ParametersType
+        ParticleT,
+        tuple[ParticleT, ...],
+        ObservationT,
+        tuple[ObservationT, ...],
+        tuple[seqjtyping.Condition, ...] | None,
+        ConditionT,
+        ParametersT,
     ]
-    proposal: Proposal[ParticleType, ObservationType, ConditionType, ParametersType]
-    resampler: Resampler
+    proposal: Proposal[ParticleT, ObservationT, ConditionT, ParametersT]
+    resampler: Resampler[ParticleT]
     num_particles: int
 
     @cached_property
@@ -157,29 +202,38 @@ class SMCSampler(
         self,
         step_key: PRNGKeyArray,
         log_w: Array,
-        particles: tuple[ParticleType, ...],
-        observation_history: tuple[ObservationType, ...],
-        observation: ObservationType,
-        condition: ConditionType,
-        params: ParametersType,
-        target_parameters: Callable = lambda x: x,
+        particles: tuple[ParticleT, ...],
+        observation_history: tuple[ObservationT, ...],
+        observation: ObservationT,
+        condition: ConditionT,
+        params: ParametersT,
+        target_parameters: Callable[[ParametersT], ParametersT] | None = None,
     ) -> tuple[
         Array,
-        tuple[ParticleType, ...],
-        tuple[ObservationType, ...],
+        tuple[ParticleT, ...],
+        tuple[ObservationT, ...],
         Scalar,
         Scalar,
         Array,
     ]:
         resample_key, proposal_key = jrandom.split(step_key)
 
+        if target_parameters is None:
+            target_parameters = cast(Callable[[ParametersT], ParametersT], lambda x: x)
+
         ess_e = compute_esse_from_log_weights(log_w)
         particles, log_w, ancestor_ix = self.resampler(
             resample_key, log_w, particles, ess_e, self.num_particles
         )
 
-        proposal_history = particles[-self.proposal.order :]
-        transition_history = particles[-self.target.transition.order :]
+        proposal_history = cast(
+            tuple[ParticleT, ...],
+            particles[-self.proposal.order :],
+        )
+        transition_history = cast(
+            tuple[ParticleT, ...],
+            particles[-self.target.transition.order :],
+        )
 
         next_particles = self.proposal_sample(
             jrandom.split(proposal_key, self.num_particles),
@@ -189,15 +243,18 @@ class SMCSampler(
             params,
         )
 
-        emission_history = (
-            particles[-(self.target.emission.order - 1) :]
+        emission_history: tuple[ParticleT, ...] = (
+            cast(tuple[ParticleT, ...], particles[-(self.target.emission.order - 1) :])
             if self.target.emission.order > 1
             else ()
         )
         emission_particles = (*emission_history, next_particles)
 
         obs_history = (
-            observation_history[-self.target.emission.observation_dependency :]
+            cast(
+                tuple[ObservationT, ...],
+                observation_history[-self.target.emission.observation_dependency :],
+            )
             if self.target.emission.observation_dependency > 0
             else ()
         )
@@ -220,32 +277,47 @@ class SMCSampler(
         log_w = log_w + inc_weight
 
         max_order = max(self.target.transition.order, self.target.emission.order)
-        particles = (*particles, next_particles)[-max_order:]
+        particles = cast(
+            tuple[ParticleT, ...],
+            (*particles, next_particles)[-max_order:],
+        )
 
         if self.target.emission.observation_dependency > 0:
-            observation_history = (*observation_history, observation)[
-                -self.target.emission.observation_dependency :
-            ]
+            observation_history = cast(
+                tuple[ObservationT, ...],
+                (*observation_history, observation)[
+                    -self.target.emission.observation_dependency :
+                ],
+            )
         else:
-            observation_history = ()
+            observation_history = cast(tuple[ObservationT, ...], ())
 
         return (log_w, particles, observation_history, ess_e, ancestor_ix, inc_weight)
 
 
-def run_filter(
-    smc: SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType],
+def run_filter[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](
+    smc: SMCSampler[ParticleT, ObservationT, ConditionT, ParametersT],
     key: PRNGKeyArray,
-    parameters: ParametersType,
-    observation_path: ObservationType,
-    condition_path: ConditionType | None = None,
+    parameters: ParametersT,
+    observation_path: ObservationT,
+    condition_path: ConditionT | None = None,
     *,
-    initial_conditions: tuple[ConditionType, ...] | None = None,
-    observation_history: tuple[ObservationType, ...] | None = None,
-    recorders: tuple[Recorder, ...] | None = None,
-    target_parameters: Callable = lambda x: x,
+    initial_conditions: tuple[seqjtyping.Condition, ...] | None = None,
+    observation_history: tuple[ObservationT, ...] | None = None,
+    recorders: tuple[
+        Recorder[ParticleT, ObservationT, ConditionT, ParametersT],
+        ...,
+    ]
+    | None = None,
+    target_parameters: Callable[[ParametersT], ParametersT] | None = None,
 ) -> tuple[
     Array,
-    tuple[ParticleType, ...],
+    tuple[ParticleT, ...],
     tuple[PyTree, ...],
 ]:
     """
@@ -261,28 +333,34 @@ def run_filter(
             raise ValueError(
                 "initial_conditions must be provided when the prior has order > 0"
             )
-        initial_conditions = ()
+        initial_conditions = cast(tuple[seqjtyping.Condition, ...], ())
 
     if observation_history is None:
         if smc.target.emission.observation_dependency > 0:
             raise ValueError(
                 "observation_history must be provided when the emission has observation dependency > 0"
             )
-        observation_history = ()
+        observation_history = cast(tuple[ObservationT, ...], ())
 
     if condition_path is None:
-        initial_condition = None
+        initial_condition = cast(ConditionT, None)
     else:
-        initial_condition = util.index_pytree(condition_path, 0)
+        initial_condition = cast(ConditionT, util.index_pytree(condition_path, 0))
+
+    if target_parameters is None:
+        target_parameters = cast(Callable[[ParametersT], ParametersT], lambda x: x)
 
     init_key, *step_keys = jrandom.split(key, sequence_length)
 
     # Run initial step, this needs special handling because we sample from prior
     # rather than the proposal.
-    init_particles = jax.vmap(smc.target.prior.sample, in_axes=[0, None, None])(
-        jrandom.split(init_key, smc.num_particles),
-        initial_conditions,
-        target_parameters(parameters),
+    init_particles = cast(
+        tuple[ParticleT, ...],
+        jax.vmap(smc.target.prior.sample, in_axes=[0, None, None])(
+            jrandom.split(init_key, smc.num_particles),
+            initial_conditions,
+            target_parameters(parameters),
+        ),
     )
     log_weights = smc.emission_logp(
         init_particles,
@@ -297,7 +375,12 @@ def run_filter(
             util.index_pytree(observation_path, 0),
         )
 
-    filter_data = FilterData(
+    filter_data: FilterData[
+        ParticleT,
+        ObservationT,
+        ConditionT,
+        ParametersT,
+    ] = FilterData(
         log_w=log_weights,
         particles=init_particles,
         ancestor_ix=jnp.full((smc.num_particles,), -1, dtype=jnp.int32),
@@ -305,8 +388,11 @@ def run_filter(
         obs_hist=observation_history,
         condition=initial_condition,
         last_log_w=jnp.zeros(smc.num_particles),
-        last_particles=jax.tree_util.tree_map(
-            lambda x: jnp.full_like(x, fill_value=-1.0), init_particles
+        last_particles=cast(
+            tuple[ParticleT, ...],
+            jax.tree_util.tree_map(
+                lambda x: jnp.full_like(x, fill_value=-1.0), init_particles
+            ),
         ),
         ess_e=compute_esse_from_log_weights(log_weights),
         log_weight_increment=log_weights,
@@ -321,6 +407,9 @@ def run_filter(
         step_key, observation, condition = inputs
         last_log_w, last_particles, obs_hist = state
 
+        observation = cast(ObservationT, observation)
+        condition = cast(ConditionT, condition)
+
         log_w, particles, obs_hist, ess_e, ancestor_ix, weight_inc = smc.sample_step(
             step_key,
             last_log_w,
@@ -331,7 +420,12 @@ def run_filter(
             parameters,
             target_parameters,
         )
-        filter_data = FilterData(
+        filter_data: FilterData[
+            ParticleT,
+            ObservationT,
+            ConditionT,
+            ParametersT,
+        ] = FilterData(
             log_w=log_w,
             particles=particles,
             ancestor_ix=ancestor_ix,
@@ -381,19 +475,28 @@ def run_filter(
     )
 
 
-def vmapped_run_filter(
-    smc: SMCSampler[ParticleType, ObservationType, ConditionType, ParametersType],
+def vmapped_run_filter[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](
+    smc: SMCSampler[ParticleT, ObservationT, ConditionT, ParametersT],
     key: Array,
-    parameters: ParametersType,
-    observation_path: ObservationType,
-    condition_path: ObservationType | None = None,
+    parameters: ParametersT,
+    observation_path: ObservationT,
+    condition_path: ConditionT | None = None,
     *,
-    initial_conditions: tuple[ConditionType, ...] | None = None,
-    observation_history: tuple[ObservationType, ...] | None = None,
-    recorders: tuple[Recorder, ...] | None = None,
+    initial_conditions: tuple[seqjtyping.Condition, ...] | None = None,
+    observation_history: tuple[ObservationT, ...] | None = None,
+    recorders: tuple[
+        Recorder[ParticleT, ObservationT, ConditionT, ParametersT],
+        ...,
+    ]
+    | None = None,
 ) -> tuple[
     Array,
-    tuple[ParticleType, ...],
+    tuple[ParticleT, ...],
     Array,
     tuple[PyTree, ...],
 ]:

--- a/seqjax/inference/particlefilter/recorders.py
+++ b/seqjax/inference/particlefilter/recorders.py
@@ -6,6 +6,8 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree
 
+import seqjax.model.typing as seqjtyping
+
 from .base import FilterData
 
 
@@ -16,7 +18,12 @@ def _normalised_weights(log_w: Array) -> Array:
     return w / jnp.sum(w)
 
 
-def current_particle_mean(filter_data: FilterData) -> PyTree:
+def current_particle_mean[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](filter_data: FilterData[ParticleT, ObservationT, ConditionT, ParametersT]) -> PyTree:
     """Record the weighted mean of the current particles."""
 
     weights = _normalised_weights(filter_data.log_w)
@@ -45,8 +52,13 @@ def _weighted_quantiles(values: Array, weights: Array, qs: Array) -> Array:
     return jnp.stack([_interp(q) for q in qs])
 
 
-def current_particle_quantiles(
-    filter_data: FilterData,
+def current_particle_quantiles[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](
+    filter_data: FilterData[ParticleT, ObservationT, ConditionT, ParametersT],
     *,
     quantiles: Sequence[float] = (0.1, 0.9),
 ) -> PyTree:
@@ -64,7 +76,12 @@ def current_particle_quantiles(
     return jax.tree_util.tree_map(_quant, particle)
 
 
-def current_particle_variance(filter_data: FilterData) -> PyTree:
+def current_particle_variance[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](filter_data: FilterData[ParticleT, ObservationT, ConditionT, ParametersT]) -> PyTree:
     """Record the weighted variance of the current particles."""
 
     weights = _normalised_weights(filter_data.log_w)
@@ -78,7 +95,12 @@ def current_particle_variance(filter_data: FilterData) -> PyTree:
     return jax.tree_util.tree_map(_var, particle)
 
 
-def log_marginal(filter_data: FilterData) -> PyTree:
+def log_marginal[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](filter_data: FilterData[ParticleT, ObservationT, ConditionT, ParametersT]) -> PyTree:
     """Record the log marginal likelihood increment at each step."""
 
     log_w_increment = filter_data.log_weight_increment
@@ -88,7 +110,12 @@ def log_marginal(filter_data: FilterData) -> PyTree:
     return jnp.log(w_sum) + lw_max - jnp.log(filter_data.ancestor_ix.shape[0])
 
 
-def effective_sample_size(filter_data: FilterData) -> PyTree:
+def effective_sample_size[
+    ParticleT: seqjtyping.Particle,
+    ObservationT: seqjtyping.Observation,
+    ConditionT: seqjtyping.Condition | None,
+    ParametersT: seqjtyping.Parameters,
+](filter_data: FilterData[ParticleT, ObservationT, ConditionT, ParametersT]) -> PyTree:
     """Record the effective sample size at each step."""
 
     return filter_data.ess_e


### PR DESCRIPTION
## Summary
- refactor the particle filter core to use explicit type-parameterised data containers and proposal adapters that match the updated sequential model interfaces
- update bootstrap/auxiliary filter definitions, recorder utilities, and resampling helpers to follow the new generic typing scheme
- switch the recorder protocol to inline type-parameter syntax instead of standalone `TypeVar` declarations

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_68cd5701590c832597fefc5ec81ecb67