### PR TITLE
Add typing annotations to VI training module

### DIFF
--- a/seqjax/inference/vi/train.py
+++ b/seqjax/inference/vi/train.py
@@ -1,20 +1,36 @@
 import time
-from typing import Optional, Any, Iterator, Protocol
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    MutableMapping,
+    Protocol,
+    TypeVar,
+    TypeAlias,
+)
 import typing
 
-import jaxtyping
-
 from functools import partial
+
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
 import jax.tree_util as jtu
-
-
-import equinox as eqx
+import jaxtyping
+import optax  # type: ignore[import-untyped]
+from jaxtyping import PyTree
+from jax.sharding import Sharding
 
 from tqdm.auto import trange  # type: ignore[import-untyped]
 from tqdm.notebook import trange as nbtrange  # type: ignore[import-untyped]
+
+from seqjax.model.base import BayesianSequentialModel
+from seqjax.inference.vi.base import (
+    SSMVariationalApproximation,
+    BufferedSSMVI,
+)
+import seqjax.model.typing as seqjtyping
 
 
 class _ProgressIterator(Protocol):
@@ -23,30 +39,132 @@ class _ProgressIterator(Protocol):
     def set_postfix(self, *args: Any, **kwargs: Any) -> None: ...
 
 
-from seqjax.model.base import BayesianSequentialModel
-from seqjax.inference.vi.base import (
-    SSMVariationalApproximation,
-    BufferedSSMVI,
+ParticleT = TypeVar("ParticleT", bound=seqjtyping.Particle)
+InitialParticleT = TypeVar(
+    "InitialParticleT", bound=tuple[seqjtyping.Particle, ...]
 )
-import seqjax.model.typing
+TransitionParticleHistoryT = TypeVar(
+    "TransitionParticleHistoryT", bound=tuple[seqjtyping.Particle, ...]
+)
+ObservationParticleHistoryT = TypeVar(
+    "ObservationParticleHistoryT", bound=tuple[seqjtyping.Particle, ...]
+)
+ObservationT = TypeVar("ObservationT", bound=seqjtyping.Observation)
+ObservationHistoryT = TypeVar(
+    "ObservationHistoryT", bound=tuple[seqjtyping.Observation, ...]
+)
+ConditionHistoryT = TypeVar(
+    "ConditionHistoryT", bound=tuple[seqjtyping.Condition, ...]
+)
+ConditionT = TypeVar("ConditionT", bound=seqjtyping.Condition)
+ParametersT = TypeVar("ParametersT", bound=seqjtyping.Parameters)
+InferenceParametersT = TypeVar(
+    "InferenceParametersT", bound=seqjtyping.Parameters
+)
+HyperParametersT = TypeVar("HyperParametersT", bound=seqjtyping.HyperParameters)
+
+SSMApproximationT = SSMVariationalApproximation[
+    ParticleT,
+    InitialParticleT,
+    TransitionParticleHistoryT,
+    ObservationParticleHistoryT,
+    ObservationT,
+    ObservationHistoryT,
+    ConditionHistoryT,
+    ConditionT,
+    ParametersT,
+    InferenceParametersT,
+    HyperParametersT,
+]
+BufferedApproximationT = BufferedSSMVI[
+    ParticleT,
+    InitialParticleT,
+    TransitionParticleHistoryT,
+    ObservationParticleHistoryT,
+    ObservationT,
+    ObservationHistoryT,
+    ConditionHistoryT,
+    ConditionT,
+    ParametersT,
+    InferenceParametersT,
+    HyperParametersT,
+]
+TargetModelT = BayesianSequentialModel[
+    ParticleT,
+    InitialParticleT,
+    TransitionParticleHistoryT,
+    ObservationParticleHistoryT,
+    ObservationT,
+    ObservationHistoryT,
+    ConditionHistoryT,
+    ConditionT,
+    ParametersT,
+    InferenceParametersT,
+    HyperParametersT,
+]
+
+TrainableModuleT = TypeVar("TrainableModuleT", bound=eqx.Module)
+StaticModuleT = TypeVar("StaticModuleT", bound=eqx.Module)
+OptStateT = TypeVar("OptStateT")
+
+LoggedArray = jaxtyping.Float[jaxtyping.Array, "..."]
+LoggedValue = float | int | LoggedArray
+TrackerLogRow = MutableMapping[str, LoggedValue]
+
+ArrayTree: TypeAlias = PyTree[LoggedArray]
+
+LossFunction = Callable[
+    [
+        TrainableModuleT,
+        StaticModuleT,
+        ObservationT,
+        ConditionT | None,
+        jaxtyping.PRNGKeyArray,
+    ],
+    jaxtyping.Scalar,
+]
+
+CompiledStepFn = Callable[
+    [
+        TrainableModuleT,
+        StaticModuleT,
+        OptStateT,
+        ObservationT,
+        ConditionT | None,
+        jaxtyping.PRNGKeyArray,
+    ],
+    tuple[jaxtyping.Scalar, TrainableModuleT, OptStateT],
+]
+
+LossAndGradFn = Callable[
+    [
+        TrainableModuleT,
+        StaticModuleT,
+        ObservationT,
+        ConditionT | None,
+        jaxtyping.PRNGKeyArray,
+    ],
+    tuple[jaxtyping.Scalar, TrainableModuleT],
+]
 
 
 def loss_buffered_neg_elbo(
-    trainable,
-    static,
-    observations,
-    conditions,
-    key,
-    target_posterior,
-    num_context,
-    samples_per_context,
-):
-    # build full model for sampling
-    approximation: SSMVariationalApproximation = eqx.combine(trainable, static)
+    trainable: TrainableModuleT,
+    static: StaticModuleT,
+    observations: ObservationT,
+    conditions: ConditionT | None,
+    key: jaxtyping.PRNGKeyArray,
+    target_posterior: TargetModelT,
+    num_context: int,
+    samples_per_context: int,
+) -> jaxtyping.Scalar:
+    approximation = typing.cast(
+        SSMApproximationT, eqx.combine(trainable, static)
+    )
 
     return approximation.estimate_loss(
         observations,
-        conditions,
+        typing.cast(ConditionT, conditions),
         key,
         num_context,
         samples_per_context,
@@ -56,21 +174,22 @@ def loss_buffered_neg_elbo(
 
 
 def loss_pre_train_neg_elbo(
-    trainable,
-    static,
-    observations,
-    conditions,
-    key,
-    target_posterior,
-    num_context,
-    samples_per_context,
-):
-    # build full model for sampling
-    approximation: BufferedSSMVI = eqx.combine(trainable, static)
+    trainable: TrainableModuleT,
+    static: StaticModuleT,
+    observations: ObservationT,
+    conditions: ConditionT | None,
+    key: jaxtyping.PRNGKeyArray,
+    target_posterior: TargetModelT,
+    num_context: int,
+    samples_per_context: int,
+) -> jaxtyping.Scalar:
+    approximation = typing.cast(
+        BufferedApproximationT, eqx.combine(trainable, static)
+    )
 
     return approximation.estimate_pretrain_loss(
         observations,
-        conditions,
+        typing.cast(ConditionT, conditions),
         key,
         num_context,
         samples_per_context,
@@ -80,16 +199,23 @@ def loss_pre_train_neg_elbo(
 
 
 class LocalTracker:
-    def __init__(self):
+    rows: list[TrackerLogRow]
+
+    def __init__(self) -> None:
         self.rows = []
 
-    def log(self, data):
+    def log(self, data: TrackerLogRow) -> None:
         self.rows.append(data)
 
 
 @eqx.filter_jit
-def sample_theta_qs(static, trainable, key, metric_samples):
-    model: SSMVariationalApproximation = eqx.combine(static, trainable)
+def sample_theta_qs(
+    static: StaticModuleT,
+    trainable: TrainableModuleT,
+    key: jaxtyping.PRNGKeyArray,
+    metric_samples: int,
+) -> tuple[ArrayTree, ArrayTree, ArrayTree]:
+    model = typing.cast(SSMApproximationT, eqx.combine(static, trainable))
     parameter_keys = jrandom.split(key, metric_samples)
     theta, _ = jax.vmap(model.parameter_approximation.sample_and_log_prob)(
         parameter_keys, None
@@ -98,28 +224,48 @@ def sample_theta_qs(static, trainable, key, metric_samples):
         lambda x: jnp.quantile(x, jnp.array([0.05, 0.95])), theta
     )
     means = jax.tree_util.tree_map(lambda x: jnp.mean(x), theta)
-    return qs, means, theta
+    return (
+        typing.cast(ArrayTree, qs),
+        typing.cast(ArrayTree, means),
+        typing.cast(ArrayTree, theta),
+    )
 
 
 class DefaultTracker:
-    def __init__(self, record_interval=100, metric_samples=100):
+    record_interval: int
+    metric_samples: int
+    elapsed_time_s: float
+    update_rows: list[TrackerLogRow]
+    checkpoint_samples: list[tuple[float, ArrayTree]]
+    train_phase_start_time: float
+
+    def __init__(self, record_interval: int = 100, metric_samples: int = 100) -> None:
         self.record_interval = record_interval
         self.metric_samples = metric_samples
-        self.elapsed_time_s = 0
+        self.elapsed_time_s = 0.0
         self.update_rows = []
         self.checkpoint_samples = []
+        self.train_phase_start_time = 0.0
 
-    def start_run(self):
+    def start_run(self) -> None:
         self.train_phase_start_time = time.time()
 
-    def track_step(self, static, trainable, opt_step, loss, key, loop):
+    def track_step(
+        self,
+        static: StaticModuleT,
+        trainable: TrainableModuleT,
+        opt_step: int,
+        loss: jaxtyping.Scalar,
+        key: jaxtyping.PRNGKeyArray,
+        loop: _ProgressIterator,
+    ) -> None:
         if (opt_step + 1) % self.record_interval == 0:
             jax.device_get(loss)  # sync
 
             # increment elapsed time by the time of this train phase
             self.elapsed_time_s += time.time() - self.train_phase_start_time
 
-            update = {
+            update: TrackerLogRow = {
                 "step": int(opt_step + 1),
                 "loss": float(loss),
                 "elapsed_time_s": self.elapsed_time_s,
@@ -148,25 +294,26 @@ class DefaultTracker:
 
 
 def train(
-    model: SSMVariationalApproximation,
-    observations: seqjax.model.typing.Observation,
-    conditions: Optional[seqjax.model.typing.Condition],
-    target: BayesianSequentialModel,
+    model: SSMApproximationT,
+    observations: ObservationT,
+    conditions: ConditionT | None,
+    target: TargetModelT,
     *,
-    key,
-    optim,
-    run_tracker: DefaultTracker,
-    num_steps=1000,
-    filter_spec=None,
+    key: jaxtyping.PRNGKeyArray,
+    optim: optax.GradientTransformation,
+    run_tracker: DefaultTracker | None,
+    num_steps: int = 1000,
+    filter_spec: PyTree[bool] | None = None,
     observations_per_step: int = 5,
     samples_per_context: int = 10,
     pre_train: bool = False,
-    device_sharding: Optional[Any] = None,
-    nb_context=False,
-) -> SSMVariationalApproximation:
+    device_sharding: Sharding | None = None,
+    nb_context: bool = False,
+) -> SSMApproximationT:
     # set up record if needed
     if run_tracker is None:
         run_tracker = DefaultTracker()
+    run_tracker = typing.cast(DefaultTracker, run_tracker)
 
     # optimizer initailisation
     if filter_spec is None:
@@ -176,46 +323,54 @@ def train(
     opt_state = optim.init(trainable)
 
     # loss configuration
-    if pre_train:
-        loss_fn = loss_pre_train_neg_elbo
-    else:
-        loss_fn = loss_buffered_neg_elbo
-
-    loss_and_grad = jax.value_and_grad(
+    base_loss_fn: Callable[..., jaxtyping.Scalar]
+    base_loss_fn = loss_pre_train_neg_elbo if pre_train else loss_buffered_neg_elbo
+    loss_fn = typing.cast(
+        LossFunction,
         partial(
-            loss_fn,
+            base_loss_fn,
             target_posterior=target,
             num_context=samples_per_context,
             samples_per_context=observations_per_step,
-        )
+        ),
     )
+
+    loss_and_grad: LossAndGradFn = jax.value_and_grad(loss_fn)
 
     # main training step
     step_keys = jrandom.split(key, num_steps)
 
-    def make_step(trainable, static, opt_state, observations, conditions, key):
-        loss, grads = loss_and_grad(trainable, static, observations, conditions, key)
-        updates, opt_state = optim.update(grads, opt_state, params=trainable)
-        trainable = eqx.apply_updates(trainable, updates)
-        return loss, trainable, opt_state
+    def make_step(
+        trainable_in: TrainableModuleT,
+        static_in: StaticModuleT,
+        opt_state_in: OptStateT,
+        observations_in: ObservationT,
+        conditions_in: ConditionT | None,
+        key_in: jaxtyping.PRNGKeyArray,
+    ) -> tuple[jaxtyping.Scalar, TrainableModuleT, OptStateT]:
+        loss, grads = loss_and_grad(
+            trainable_in,
+            static_in,
+            observations_in,
+            typing.cast(ConditionT, conditions_in),
+            key_in,
+        )
+        updates, opt_state_next = optim.update(
+            grads, opt_state_in, params=trainable_in
+        )
+        trainable_next = eqx.apply_updates(trainable_in, updates)
+        return (
+            loss,
+            typing.cast(TrainableModuleT, trainable_next),
+            typing.cast(OptStateT, opt_state_next),
+        )
 
     # compile
-    compiled_make_step: typing.Callable[
-        [
-            eqx.Module,
-            eqx.Module,
-            typing.Any,
-            seqjax.model.typing.Observation,
-            Optional[seqjax.model.typing.Condition],
-            jaxtyping.PRNGKeyArray,
-        ],
-        tuple[jaxtyping.Scalar, eqx.Module, eqx.Module],
-    ] = (
-        typing.cast(
-            typing.Any, eqx.filter_jit(make_step)
-        )  # mypy can't infer appropriate form
+    compiled_make_step = typing.cast(
+        CompiledStepFn,
+        typing.cast(Any, eqx.filter_jit(make_step))
         .lower(trainable, static, opt_state, observations, conditions, step_keys[0])
-        .compile()
+        .compile(),
     )
 
     # train loop
@@ -242,4 +397,4 @@ def train(
             static, trainable, opt_step, loss, step_keys[opt_step], loop
         )
 
-    return eqx.combine(static, trainable)
+    return typing.cast(SSMApproximationT, eqx.combine(static, trainable))


### PR DESCRIPTION
## Summary
- introduce generics and helper type aliases to model SSM approximations, optimizer state, and logged metrics in the VI training module
- add explicit annotations for the ELBO helpers, tracker classes, and sampling utility to reflect the shapes of recorded data
- refine the `train` API and step compilation to use the new typing helpers and return the fully combined approximation

## Testing
- pytest *(fails: GaussianPrior signature mismatch in existing linear Gaussian model test)*
- mypy seqjax/inference/vi/train.py
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce6845759883259fa4e6aedf22bd38