### PR TITLE
Add coverage for inference registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     "jaxtyping>=0.2.38",
     "graphviz",
     "blackjax",
+    "distrax",
+    "jax_tqdm",
+    "tqdm",
     "wandb",
 ]
 

--- a/tests/inference/test_registry_inference.py
+++ b/tests/inference/test_registry_inference.py
@@ -1,0 +1,154 @@
+"""Tests covering all registered inference methods."""
+
+from collections.abc import Iterator
+
+import jax.numpy as jnp
+import jax.random as jrandom
+import pytest
+
+from _pytest.mark.structures import ParameterSet
+
+from tqdm import auto as tqdm_auto
+from tqdm import notebook as tqdm_notebook
+
+from seqjax.inference import mcmc, registry as inference_registry, vi
+from seqjax.model import ar, registry as model_registry, simulate
+
+
+class _DummyTqdmIterator(Iterator[int]):
+    """Minimal iterator with ``set_postfix`` to satisfy ``tqdm`` usage in tests."""
+
+    def __init__(self, n: int) -> None:
+        self._iter = iter(range(int(n)))
+
+    def __iter__(self) -> "_DummyTqdmIterator":
+        return self
+
+    def __next__(self) -> int:
+        return next(self._iter)
+
+    def set_postfix(self, *_args, **_kwargs) -> None:  # pragma: no cover - behaviourless stub
+        """Match the API used in :mod:`seqjax.inference.vi.train`."""
+
+@pytest.fixture(autouse=True)
+def _stub_tqdm_trange(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``tqdm`` progress bars with a deterministic iterator."""
+
+    def _trange(n: int, *_args, **_kwargs) -> _DummyTqdmIterator:
+        return _DummyTqdmIterator(n)
+
+    monkeypatch.setattr(tqdm_auto, "trange", _trange)
+    monkeypatch.setattr(tqdm_notebook, "trange", _trange)
+
+
+INFERENCE_TEST_SETUPS: dict[str, tuple[object, int]] = {
+    "NUTS": (
+        mcmc.NUTSConfig(step_size=1e-1, num_adaptation=5, num_warmup=5, num_chains=1),
+        10,
+    ),
+    "buffer-vi": (
+        vi.BufferedVIConfig(
+            learning_rate=1e-2,
+            opt_steps=2,
+            buffer_length=2,
+            batch_length=4,
+            parameter_field_bijections={"ar": "sigmoid"},
+            observations_per_step=1,
+            samples_per_context=1,
+            nn_width=4,
+            nn_depth=1,
+            control_variate=False,
+            pre_training_steps=0,
+        ),
+        200,
+    ),
+    "full-vi": (
+        vi.FullVIConfig(
+            learning_rate=1e-2,
+            opt_steps=2,
+            parameter_field_bijections={"ar": "sigmoid"},
+            prev_window=1,
+            post_window=1,
+            observations_per_step=1,
+            samples_per_context=1,
+        ),
+        200,
+    ),
+}
+
+
+def _iter_registry_entries() -> list[ParameterSet]:
+    entries: list[ParameterSet] = []
+    for index, (method_label, inference_fn) in enumerate(
+        inference_registry.inference_functions.items()
+    ):
+        config_entry = INFERENCE_TEST_SETUPS.get(method_label)
+        if config_entry is None:
+            raise AssertionError(f"Missing test configuration for inference method {method_label!r}")
+        config, test_samples = config_entry
+        entries.append(
+            pytest.param(
+                method_label,
+                inference_fn,
+                config,
+                test_samples,
+                index,
+                id=method_label,
+            )
+        )
+    return entries
+
+
+@pytest.fixture(scope="module")
+def ar1_problem() -> tuple[ar.AR1Bayesian, ar.NoisyEmission]:
+    """Simulate a short AR(1) path that can be reused across inference tests."""
+
+    sequence_length = 10
+    parameters = model_registry.parameter_settings["ar"]["base"]
+    posterior = ar.AR1Bayesian(parameters)
+    _latents, observations, _latent_history, _observation_history = simulate.simulate(
+        jrandom.PRNGKey(0),
+        posterior.target,
+        condition=None,
+        parameters=parameters,
+        sequence_length=sequence_length,
+    )
+    assert observations.batch_shape[0] == sequence_length
+    return posterior, observations
+
+
+@pytest.mark.parametrize(
+    "method_label,inference_fn,config,test_samples,case_index",
+    _iter_registry_entries(),
+)
+def test_registered_inference_methods_can_run(
+    method_label: str,
+    inference_fn,
+    config,
+    test_samples: int,
+    case_index: int,
+    ar1_problem: tuple[ar.AR1Bayesian, ar.NoisyEmission],
+) -> None:
+    """Every registered inference routine should execute on the AR(1) example."""
+
+    posterior, observations = ar1_problem
+    key = jrandom.fold_in(jrandom.PRNGKey(2024), case_index)
+
+    parameter_samples, extra_data = inference_fn(
+        posterior,
+        hyperparameters=None,
+        key=key,
+        observation_path=observations,
+        condition_path=None,
+        test_samples=test_samples,
+        config=config,
+    )
+
+    assert isinstance(parameter_samples, ar.AROnlyParameters)
+
+    ar_samples = jnp.asarray(parameter_samples.ar)
+    assert ar_samples.shape[-1] == test_samples
+    assert ar_samples.size > 0
+    assert bool(jnp.isfinite(ar_samples).all())
+
+    assert isinstance(extra_data, tuple)


### PR DESCRIPTION
## Summary
- add missing runtime dependencies required by inference methods
- add a generic AR(1) integration test that exercises every registered inference backend
- replace the fake sys.modules tqdm injection with a pytest fixture that patches the real tqdm progress bars

## Testing
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce848bcac48325a5a0ef347d6fe0c1