### PR TITLE
Add double well condition helpers and registry plumbing

### DIFF
--- a/seqjax/model/evaluate.py
+++ b/seqjax/model/evaluate.py
@@ -62,7 +62,11 @@ def log_prob_x(
         sequence_start + 1,
         sequence_start + sequence_length,
     )
-    transition_condition = slice_pytree(condition, sequence_start, sequence_length)
+    transition_condition = slice_pytree(
+        condition,
+        sequence_start + 1,
+        sequence_start + sequence_length,
+    )
 
     transition_log_p_x = jax.vmap(target.transition.log_prob, in_axes=[0, 0, 0, None])(
         particle_history,

--- a/tests/models/test_registry_models.py
+++ b/tests/models/test_registry_models.py
@@ -42,10 +42,17 @@ def test_registered_models_can_simulate_and_evaluate(
     sequence_length = 5
     key = jrandom.PRNGKey(0)
 
+    condition_factory = registry.condition_generators.get(model_label)
+    condition = (
+        None
+        if condition_factory is None
+        else condition_factory(sequence_length)
+    )
+
     latents, observations, latent_history, observation_history = simulate.simulate(
         key,
         target,
-        condition=None,
+        condition=condition,
         parameters=parameters,
         sequence_length=sequence_length,
     )
@@ -58,7 +65,7 @@ def test_registered_models_can_simulate_and_evaluate(
     log_p_x = evaluate.log_prob_x(
         target,
         latents,
-        condition=None,
+        condition=condition,
         parameters=parameters,
         x_history=latent_history,
     )
@@ -66,7 +73,7 @@ def test_registered_models_can_simulate_and_evaluate(
         target,
         latents,
         observation_path,
-        condition=None,
+        condition=condition,
         parameters=parameters,
         x_history=latent_history,
     )
@@ -74,7 +81,7 @@ def test_registered_models_can_simulate_and_evaluate(
         target,
         latents,
         observation_path,
-        condition=None,
+        condition=condition,
         parameters=parameters,
         x_history=latent_history,
     )


### PR DESCRIPTION
## Summary
- require explicit time increments in the double well transition and add a helper to build unit-length increment pytrees
- register the double well model with parameter presets and a condition generator hook
- adjust registry model tests and log-prob evaluation to supply the generated conditions
- restore the registry module documentation to describe the three coordinated registries

## Testing
- pip install .[dev]
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce87874f0083258e35287ce820253d