### PR TITLE
Add Equinox Module stub

### DIFF
--- a/stubs/equinox/_module/_module.pyi
+++ b/stubs/equinox/_module/_module.pyi
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import dataclasses
+from abc import ABCMeta
+from collections.abc import Callable, Hashable
+from dataclasses import Field as DataclassField
+from typing import Any, TypeVar
+from typing import dataclass_transform
+
+_ModuleT = TypeVar("_ModuleT", bound="Module")
+
+
+def field(
+    *,
+    converter: Callable[[Any], Any] | None = ...,
+    static: bool = ...,
+    **kwargs: Any,
+) -> DataclassField[Any]: ...
+
+
+@dataclass_transform(field_specifiers=(dataclasses.field, field))
+class _ModuleMeta(ABCMeta):
+    def __call__(cls: type[_ModuleT], *args: Any, **kwargs: Any) -> _ModuleT: ...
+
+
+class Module(Hashable, metaclass=_ModuleMeta):
+    def __hash__(self) -> int: ...
+
+    def __eq__(self, other: Any) -> bool: ...


### PR DESCRIPTION
## Summary
- add a custom `equinox._module._module` stub that exposes `Module`, its metaclass, and `field`
- retain the dataclass metadata while omitting the permissive `__getattribute__` so mypy flags invalid attribute access

## Testing
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce87b1f10c8325a5c4fe6bd82b870d