### PR TITLE
Register particle MCMC inference routine

### DIFF
--- a/tests/inference/test_registry_inference.py
+++ b/tests/inference/test_registry_inference.py
@@ -11,7 +11,13 @@ from _pytest.mark.structures import ParameterSet
 from tqdm import auto as tqdm_auto
 from tqdm import notebook as tqdm_notebook
 
-from seqjax.inference import mcmc, registry as inference_registry, vi
+from seqjax.inference import (
+    mcmc,
+    particlefilter,
+    pmcmc,
+    registry as inference_registry,
+    vi,
+)
 from seqjax.model import ar, registry as model_registry, simulate
 
 
@@ -73,6 +79,17 @@ INFERENCE_TEST_SETUPS: dict[str, tuple[object, int]] = {
             samples_per_context=1,
         ),
         200,
+    ),
+    "particle-mcmc": (
+        pmcmc.ParticleMCMCConfig(
+            particle_filter=particlefilter.BootstrapParticleFilter(
+                target=ar.AR1Target(),
+                num_particles=8,
+            ),
+            mcmc=mcmc.RandomWalkConfig(step_size=0.05),
+            initial_parameter_guesses=3,
+        ),
+        20,
     ),
 }
 


### PR DESCRIPTION
## Summary
- register the particle MCMC inference routine alongside existing entries
- provide a registry configuration dataclass for particle MCMC consumers
- add a particle MCMC setup to the registry tests using a bootstrap particle filter
- enrich the particle MCMC registry name with particle count and step size details while reading config attributes directly

## Testing
- pip install .[dev]
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce8ea98a548325babde85fc44d0df0