### PR TITLE
docs: expand landing page content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,48 @@
 # SeqJAX
 
-SeqJAX provides utilities for building sequential probabilistic models with [JAX](https://github.com/google/jax). Models are composed of `Prior`, `Transition`, and `Emission` classes operating on simple dataclasses for particles, observations, and parameters. Runtime interface checks ensure that these components implement the correct methods and signatures, reducing boilerplate errors.
+SeqJAX provides utilities for building sequential probabilistic models with [JAX](https://github.com/google/jax). The library encourages a functional style where models are composed of `Prior`, `Transition`, and `Emission` classes that operate on simple dataclasses for particles, observations, and parameters. Runtime interface checks ensure that these components implement the required methods and signatures, reducing boilerplate errors when extending or experimenting with new models.
+
+## Feature overview
+
+- **Composable building blocks.** Combine prior, transition, and emission components into a single `SequentialModel` definition.
+- **Runtime interface validation.** Helpful checks catch mistakes such as missing `sample` or `log_prob` implementations while you iterate.
+- **Demonstration models included.** Explore AR(1), stochastic volatility, and multidimensional linear Gaussian state space models to understand the provided abstractions.
+
+## Installation
+
+SeqJAX requires Python 3.12 or later. Install the latest version directly from the source repository:
+
+```bash
+pip install git+https://github.com/bayesianshift/seqjax.git
+```
+
+## Quick start
+
+The `seqjax.model.ar` module contains a small autoregressive example. The snippet below defines a model using the building blocks above and simulates a short path of data.
+
+```python
+import jax.random as jrandom
+from seqjax.model.ar import AR1Target, ARParameters
+from seqjax import simulate
+
+parameters = ARParameters(
+    ar=0.8,
+    observation_std=1.0,
+    transition_std=0.5,
+)
+model = AR1Target()
+
+key = jrandom.key(0)
+
+latent_path, observation_path, latent_hist, obs_hist = simulate.simulate(
+    key, model, condition=None, parameters=parameters, sequence_length=5,
+)
+print(observation_path)
+```
+
+SeqJAX checks at runtime that `AR1Target` and its components implement the required interface, making it easier to extend or customize the library.
+
+## Explore further
+
+- Follow the [Getting Started tutorial](tutorials/getting-started.md) to walk through the autoregressive model step by step.
+- Browse the [API reference](api.md) for detailed documentation of available classes and functions.


### PR DESCRIPTION
## Summary
- expand the MkDocs landing page so it mirrors the README details, including feature overview, installation steps, and quick-start example
- add prominent links to the getting started tutorial and API reference to guide readers through the docs

## Testing
- pip install .[dev]
- mkdocs build
- pytest
- mypy seqjax

------
https://chatgpt.com/codex/tasks/task_e_68ce9b6e16088325a049f5723fc97cc6