### PR TITLE
Add advanced inference tutorials and docs navigation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,16 +18,36 @@ The following sections document the public API for SeqJAX.
 
 ## Inference
 
+### Inference interfaces
+
+Utilities that standardise the inputs and outputs of inference routines. The
+[particle filtering](tutorials/particle-filtering.md),
+[Bayesian MCMC](tutorials/bayesian-mcmc.md), and
+[variational inference](tutorials/variational-inference.md) tutorials provide
+hands-on examples built on top of these interfaces.
+
 ::: seqjax.inference.interface
+
+### Kalman filtering
 
 ::: seqjax.inference.kalman
 
-::: seqjax.inference.mcmc
-
-::: seqjax.inference.pmcmc
+### Particle filtering
 
 ::: seqjax.inference.particlefilter
 
+### MCMC kernels
+
+::: seqjax.inference.mcmc
+
+### Particle MCMC
+
+::: seqjax.inference.pmcmc
+
+### Stochastic gradient Langevin dynamics
+
 ::: seqjax.inference.sgld
+
+### Variational inference
 
 ::: seqjax.inference.vi

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,9 +40,12 @@ latent_path, observation_path, latent_hist, obs_hist = simulate.simulate(
 print(observation_path)
 ```
 
-SeqJAX checks at runtime that `AR1Target` and its components implement the required interface, making it easier to extend or customize the library.
+SeqJAX checks at runtime that `AR1Target` and its components implement the required interface, making it easier to extend or customize the library. Once you are comfortable with simulation, explore the advanced inference workflows showcased in the tutorials below to analyse the resulting observation streams.
 
 ## Explore further
 
 - Follow the [Getting Started tutorial](tutorials/getting-started.md) to walk through the autoregressive model step by step.
+- Learn how to track filtering distributions with the [particle filtering walkthrough](tutorials/particle-filtering.md).
+- Infer parameters jointly with latent states in the [Bayesian MCMC guide](tutorials/bayesian-mcmc.md).
+- Optimise amortised posterior approximations using the [variational inference tutorial](tutorials/variational-inference.md).
 - Browse the [API reference](api.md) for detailed documentation of available classes and functions.

--- a/docs/tutorials/bayesian-mcmc.md
+++ b/docs/tutorials/bayesian-mcmc.md
@@ -1,0 +1,111 @@
+# Bayesian inference with NUTS
+
+SeqJAX integrates with [BlackJAX](https://blackjax-devs.github.io/blackjax/)
+to provide Hamiltonian Monte Carlo kernels for sequential models. The
+[`seqjax.inference.mcmc`](../api.md#mcmc-kernels) module exposes a convenient
+interface that handles warm-up, multiple chains, and posterior bookkeeping. In
+this tutorial we infer the AR(1) autoregressive coefficient using the
+No-U-Turn Sampler (NUTS).
+
+## Define the Bayesian model
+
+The [`AR1Bayesian`](../api.md#seqjaxmodelar) helper wraps the AR(1) state space
+model together with a prior over the autoregressive coefficient. We first
+simulate a synthetic data set that plays the role of observed measurements.
+
+```python
+import jax.numpy as jnp
+import jax.random as jrandom
+from seqjax import simulate
+from seqjax.model.ar import AR1Target, ARParameters, AR1Bayesian
+
+key = jrandom.key(0)
+true_parameters = ARParameters(
+    ar=jnp.array(0.8),
+    observation_std=jnp.array(0.5),
+    transition_std=jnp.array(0.3),
+)
+model = AR1Target()
+posterior = AR1Bayesian(true_parameters)
+
+_, observations, _, _ = simulate.simulate(
+    key,
+    model,
+    condition=None,
+    parameters=true_parameters,
+    sequence_length=200,
+)
+```
+
+The resulting `posterior` object satisfies the
+[`BayesianSequentialModel`](../api.md#seqjaxmodelbase) interface required by
+all inference routines in `seqjax.inference`.
+
+## Configure the NUTS sampler
+
+[`NUTSConfig`](../api.md#mcmc-kernels) controls the step size, warm-up length,
+and number of chains. The configuration below keeps the defaults but increases
+the number of warm-up steps to obtain a well-tuned mass matrix.
+
+```python
+from seqjax.inference.mcmc import NUTSConfig
+
+nuts_config = NUTSConfig(
+    step_size=1e-2,
+    num_adaptation=500,
+    num_warmup=1000,
+    num_chains=2,
+)
+```
+
+The sampler will draw `test_samples` posterior samples in total, split evenly
+across the requested number of chains.
+
+## Run `run_bayesian_nuts`
+
+The [`run_bayesian_nuts`](../api.md#mcmc-kernels) function executes warm-up and
+sampling in one call. It returns the posterior samples over parameters together
+with auxiliary diagnostics.
+
+```python
+from seqjax.inference.mcmc import run_bayesian_nuts
+
+parameter_samples, (draw_times_s, latent_samples) = run_bayesian_nuts(
+    target_posterior=posterior,
+    hyperparameters=None,
+    key=jrandom.key(1),
+    observation_path=observations,
+    condition_path=None,
+    test_samples=2000,
+    config=nuts_config,
+)
+```
+
+The `parameter_samples` PyTree matches the structure of
+`posterior.inference_parameter_cls`. For the AR(1) example it is an
+`AROnlyParameters` object where the `ar` field stores a one-dimensional array of
+size `test_samples`.
+
+```python
+ar_draws = parameter_samples.ar  # shape (test_samples,)
+mean_estimate = jnp.mean(ar_draws)
+credible_region = jnp.quantile(ar_draws, jnp.array([0.05, 0.95]))
+```
+
+The second output contains two diagnostics:
+
+- `draw_times_s` approximates the cumulative runtime of each posterior sample.
+  It is handy for plotting per-iteration wall-clock times.
+- `latent_samples` stores the sampled trajectories for each chain. For the AR(1)
+  model it has shape `(samples_per_chain, num_chains, sequence_length)`.
+
+## Where to go next
+
+- The [particle filtering tutorial](particle-filtering.md) shows how to compute
+  filtering distributions using the same sequential model.
+- The [variational inference tutorial](variational-inference.md) covers the
+  amortised inference API in [`seqjax.inference.vi`](../api.md#variational-inference).
+
+For additional kernels, such as random-walk Metropolis or particle MCMC, see
+the [`seqjax.inference.mcmc` API documentation](../api.md#mcmc-kernels) and the
+[`seqjax.inference.pmcmc` module reference](../api.md#particle-mcmc).

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -21,3 +21,14 @@ latent_path, observation_path, latent_hist, obs_hist = simulate.simulate(
 )
 print(observation_path)
 ```
+
+## Next steps
+
+Ready to move beyond simulation? Dive into the advanced tutorials:
+
+- [Particle filtering](particle-filtering.md) demonstrates how to track latent
+  state distributions with sequential Monte Carlo.
+- [Bayesian MCMC](bayesian-mcmc.md) walks through running Hamiltonian Monte
+  Carlo with [`seqjax.inference.mcmc`](../api.md#mcmc-kernels).
+- [Variational inference](variational-inference.md) explains the amortised
+  inference utilities in [`seqjax.inference.vi`](../api.md#variational-inference).

--- a/docs/tutorials/particle-filtering.md
+++ b/docs/tutorials/particle-filtering.md
@@ -1,0 +1,105 @@
+# Particle filtering with SeqJAX
+
+Sequential Monte Carlo (SMC) methods approximate posterior distributions over
+latent trajectories by propagating and resampling a population of particles.
+SeqJAX exposes a particle filtering API in
+[`seqjax.inference.particlefilter`](../api.md#particle-filtering) that works
+with any `SequentialModel`. This tutorial walks through fitting the autoregressive
+AR(1) example from [`seqjax.model.ar`](../api.md#seqjaxmodelar) to show the
+workflow end to end.
+
+## Simulate a reference data set
+
+We start by simulating a short path from the AR(1) model. The
+[`simulate.simulate`](../api.md#seqjaxmodelsimulate) helper generates both the
+latent trajectory and the noisy observations that we will feed to the filter.
+
+```python
+import jax.numpy as jnp
+import jax.random as jrandom
+from seqjax import simulate
+from seqjax.model.ar import AR1Target, ARParameters
+
+key = jrandom.key(0)
+true_parameters = ARParameters(
+    ar=jnp.array(0.8),
+    observation_std=jnp.array(1.0),
+    transition_std=jnp.array(0.5),
+)
+model = AR1Target()
+
+_, observations, _, _ = simulate.simulate(
+    key,
+    model,
+    condition=None,
+    parameters=true_parameters,
+    sequence_length=100,
+)
+```
+
+The `observations` PyTree is compatible with every inference routine, so the
+same object can be reused in the later MCMC and VI tutorials.
+
+## Configure the particle filter
+
+The [`BootstrapParticleFilter`](../api.md#particle-filtering) class wraps the
+standard algorithm that proposes particles from the transition model. The
+filter needs a target model, the number of particles, and an optional effective
+sample size (ESS) threshold that triggers resampling.
+
+```python
+from seqjax.inference import particlefilter
+
+smc = particlefilter.BootstrapParticleFilter(
+    target=model,
+    num_particles=256,
+    ess_threshold=0.6,
+)
+```
+
+SeqJAX also provides an [`AuxiliaryParticleFilter`](../api.md#particle-filtering)
+that adapts proposal weights using the emission model. Both variants share the
+same interface, so swapping them only requires changing the class name.
+
+## Run the filter and collect diagnostics
+
+[`particlefilter.run_filter`](../api.md#particle-filtering) performs the SMC
+pass. You can request arbitrary diagnostics by passing recorders from
+[`particlefilter.recorders`](../api.md#particle-filtering) via the `recorders`
+argument. The example below tracks the weighted particle mean and the ESS at
+each time step.
+
+```python
+log_weights, particle_states, recorder_history = particlefilter.run_filter(
+    smc,
+    key=jrandom.key(1),
+    parameters=true_parameters,
+    observation_path=observations,
+    recorders=(
+        particlefilter.current_particle_mean,
+        particlefilter.effective_sample_size,
+    ),
+)
+
+mean_path, ess_path = recorder_history
+state_mean = mean_path.x        # shape (sequence_length,)
+normalised_ess = ess_path        # shape (sequence_length,)
+```
+
+The `particle_states` output contains the final collection of particles, while
+`mean_path` and `normalised_ess` store the recorder values across time. Each
+recorder returns a PyTree that matches the latent particle structure, so the
+above code simply extracts the scalar state from the `LatentValue` dataclass.
+
+## Next steps
+
+Particle filtering pairs well with other inference routines:
+
+- Follow the [Bayesian MCMC tutorial](bayesian-mcmc.md) to infer parameters and
+  latent states jointly with Hamiltonian Monte Carlo.
+- Continue to the [variational inference tutorial](variational-inference.md) to
+  amortise posterior inference with neural networks.
+
+Refer to the [`seqjax.inference.particlefilter` API
+reference](../api.md#particle-filtering) for the full list of recorders,
+resampling schemes, and low-level utilities.

--- a/docs/tutorials/variational-inference.md
+++ b/docs/tutorials/variational-inference.md
@@ -1,0 +1,122 @@
+# Variational inference with amortised buffers
+
+Variational inference (VI) approximates the posterior with a parameterised
+family of distributions that can be optimised efficiently. SeqJAX offers two
+approaches via the [`seqjax.inference.vi`](../api.md#variational-inference)
+package: a buffered amortised approximation for long sequences and a full-path
+model that conditions on every observation simultaneously. This tutorial
+focuses on the buffered variant because it scales gracefully to streaming
+scenarios.
+
+## Prepare data and a posterior model
+
+We reuse the AR(1) example from the previous tutorials. The simulated data and
+[`AR1Bayesian`](../api.md#seqjaxmodelar) posterior provide the inputs required
+by the VI routines.
+
+```python
+import jax.numpy as jnp
+import jax.random as jrandom
+from seqjax import simulate
+from seqjax.model.ar import AR1Target, ARParameters, AR1Bayesian
+
+key = jrandom.key(0)
+true_parameters = ARParameters(
+    ar=jnp.array(0.7),
+    observation_std=jnp.array(0.6),
+    transition_std=jnp.array(0.3),
+)
+model = AR1Target()
+posterior = AR1Bayesian(true_parameters)
+
+_, observations, _, _ = simulate.simulate(
+    key,
+    model,
+    condition=None,
+    parameters=true_parameters,
+    sequence_length=400,
+)
+```
+
+A longer sequence is useful here because the amortised approximation learns a
+neural network that conditions on sliding windows of the observation stream.
+
+## Configure the buffered VI approximation
+
+[`BufferedVIConfig`](../api.md#variational-inference) tunes the optimiser,
+context window sizes, and bijective transforms applied to constrained
+parameters. The example below keeps most defaults, but specifies a sigmoid
+bijection so that the AR coefficient remains in $(-1, 1)$ and reduces the
+network width to speed up the demonstration run.
+
+```python
+from seqjax.inference.vi import BufferedVIConfig
+
+vi_config = BufferedVIConfig(
+    learning_rate=5e-3,
+    opt_steps=500,
+    buffer_length=20,
+    batch_length=30,
+    parameter_field_bijections={"ar": "sigmoid"},
+    observations_per_step=5,
+    samples_per_context=5,
+    nn_width=16,
+    nn_depth=2,
+)
+```
+
+The `buffer_length` and `batch_length` settings control how many observations
+are available when sampling mini-batches from the stream, while
+`observations_per_step` and `samples_per_context` dictate the stochastic
+estimator used for the evidence lower bound (ELBO).
+
+## Optimise with `run_buffered_vi`
+
+[`run_buffered_vi`](../api.md#variational-inference) fits the approximation and
+returns posterior samples drawn from the learned variational family. The
+function expects `test_samples` to be at least 100 because the evaluation stage
+uses 100 contexts with `test_samples / 100` samples each.
+
+```python
+from seqjax.inference.vi import run_buffered_vi
+
+parameter_samples, (buffer_start, latent_posterior, tracker) = run_buffered_vi(
+    target_posterior=posterior,
+    hyperparameters=None,
+    key=jrandom.key(1),
+    observation_path=observations,
+    condition_path=None,
+    test_samples=500,
+    config=vi_config,
+)
+```
+
+The returned `parameter_samples` PyTree matches the structure of
+`posterior.inference_parameter_cls`, but each field is flattened into a vector
+of posterior draws. For AR(1) this means `parameter_samples.ar` has shape
+`(test_samples,)` and can be analysed just like MCMC output.
+
+The tuple accompanying the samples contains useful diagnostics:
+
+- `buffer_start` is an array recording the starting index of each buffered
+  context that contributed to the amortised latent approximation.
+- `latent_posterior` contains samples of the latent states produced by the
+  amortised autoregressive network. The array has shape `(num_contexts,
+  samples_per_context, latent_dim)`.
+- `tracker` is a [`DefaultTracker`](../api.md#variational-inference) instance.
+  Inspect `tracker.update_rows` to view recorded ELBO estimates and posterior
+  quantiles during training.
+
+```python
+ar_variational_draws = parameter_samples.ar
+last_update = tracker.update_rows[-1]
+print("Final ELBO estimate:", last_update["loss"])
+```
+
+## Related resources
+
+- The [particle filtering](particle-filtering.md) and
+  [Bayesian MCMC](bayesian-mcmc.md) tutorials explore alternative inference
+  strategies using the same sequential model.
+- To operate on the entire observation path instead of buffered windows, see
+  [`run_full_path_vi`](../api.md#variational-inference).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,25 @@
 site_name: SeqJAX
 nav:
-  - Usage:
+  - Home: index.md
+  - Tutorials:
       - Getting Started: tutorials/getting-started.md
+      - Particle Filtering with SeqJAX: tutorials/particle-filtering.md
+      - Bayesian MCMC with NUTS: tutorials/bayesian-mcmc.md
+      - Variational Inference with Buffers: tutorials/variational-inference.md
   - API Reference:
-      - Models: api.md
+      - Models:
+          - Overview: api.md#models
+          - Core interfaces: api.md#core-interfaces
+          - Simulation: api.md#simulation
+          - Evaluation: api.md#evaluation
+      - Inference:
+          - Interfaces: api.md#inference-interfaces
+          - Kalman filtering: api.md#kalman-filtering
+          - Particle filtering: api.md#particle-filtering
+          - MCMC kernels: api.md#mcmc-kernels
+          - Particle MCMC: api.md#particle-mcmc
+          - Stochastic gradient Langevin dynamics: api.md#stochastic-gradient-langevin-dynamics
+          - Variational inference: api.md#variational-inference
 plugins:
   - search
   - mkdocstrings


### PR DESCRIPTION
## Summary
- add particle filtering, Bayesian MCMC, and variational inference tutorials that walk through seqjax.inference workflows
- cross-link the new tutorials from the landing page, getting started guide, and API reference
- expand the MkDocs navigation with dedicated tutorial entries and anchors for inference modules

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_68cea2aa16d0832588e13a86049c55ee