### PR TITLE
Refactor experiment harness into shared module

### DIFF
--- a/experiments/ar1_inference_comparison.py
+++ b/experiments/ar1_inference_comparison.py
@@ -1,14 +1,13 @@
 import matplotlib.pyplot as plt
 import jax
-from dataclasses import dataclass, asdict
+from dataclasses import asdict
 import jax.numpy as jnp
-import jax.random as jrandom
 import arviz as az
 import wandb
 import polars as pl
-from typing import Protocol
 
 
+from experiments.core import ExperimentConfig, ResultProcessor, run_experiment
 from seqjax import util
 from seqjax.model import registry as model_registry
 
@@ -34,31 +33,6 @@ def cumulative_quantiles_masked(samples, quantiles):
 
     return jax.vmap(compute_row)(full_samples, mask)
 
-
-class ResultProcessor(Protocol):
-    def process(
-        self,
-        run,
-        config,
-        param_samples,
-        extra_data,
-        x_path,
-        y_path,
-    ) -> None: ...
-
-
-@dataclass
-class ExperimentConfig:
-    data_config: model_registry.DataConfig
-    test_samples: int
-    fit_seed: int
-    inference: inference_registry.InferenceConfig
-
-    @property
-    def posterior_factory(self) -> model_registry.PosteriorFactory:
-        return self.data_config.posterior_factory
-
-
 class ARResultProcessor:
     def process(
         self,
@@ -68,6 +42,7 @@ class ARResultProcessor:
         extra_data,
         x_path,
         y_path,
+        condition=None,
     ) -> None:
         experiment_shorthand = (
             f"{experiment_config.inference.name} "
@@ -485,75 +460,6 @@ class ARResultProcessor:
         if rows is None:
             return pl.DataFrame()
         return pl.DataFrame(rows)
-
-
-def process_results(
-    run,
-    experiment_config,
-    param_samples,
-    extra_data,
-    x_path,
-    y_path,
-    result_processor: ResultProcessor | None,
-):
-    if result_processor is None:
-        return
-    result_processor.process(
-        run, experiment_config, param_samples, extra_data, x_path, y_path
-    )
-
-
-def run_experiment(
-    experiment_name: str,
-    experiment_config: ExperimentConfig,
-    result_processor: ResultProcessor | None = None,
-):
-    # track run data
-    config_dict = asdict(experiment_config)
-
-    wandb_run = wandb.init(
-        project=experiment_name,
-        config={
-            **config_dict,
-            "inference_name": experiment_config.inference.name,
-        },  # force inference name into config
-    )
-
-    # define target model
-    target_params = experiment_config.data_config.generative_parameters
-    model = experiment_config.posterior_factory(target_params)
-
-    # get target data
-    x_path, y_path = io.get_remote_data(wandb_run, experiment_config.data_config)
-
-    # inference init
-    inference = inference_registry.build_inference(experiment_config.inference)
-
-    param_samples, extra_data = inference(
-        model,
-        hyperparameters=None,
-        key=jrandom.key(experiment_config.fit_seed),
-        observation_path=y_path,
-        condition_path=None,
-        test_samples=experiment_config.test_samples,
-        config=experiment_config.inference.config,
-    )
-
-    process_results(
-        wandb_run,
-        experiment_config,
-        param_samples,
-        extra_data,
-        x_path,
-        y_path,
-        result_processor,
-    )
-
-    wandb_run.finish()
-
-    return (param_samples, extra_data, x_path, y_path)
-
-
 """
 Select inference methods to run
 """

--- a/experiments/core.py
+++ b/experiments/core.py
@@ -1,0 +1,117 @@
+"""Shared experiment harness utilities."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+import jax.random as jrandom
+import wandb
+
+from seqjax import io
+from seqjax.inference import registry as inference_registry
+from seqjax.model import registry as model_registry
+
+
+class ResultProcessor(Protocol):
+    """Protocol for experiment-specific result processing."""
+
+    def process(
+        self,
+        run: Any,
+        config: "ExperimentConfig",
+        param_samples: Any,
+        extra_data: Any,
+        x_path: Any,
+        y_path: Any,
+        condition: Any,
+    ) -> None: ...
+
+
+@dataclass
+class ExperimentConfig:
+    data_config: model_registry.DataConfig
+    test_samples: int
+    fit_seed: int
+    inference: inference_registry.InferenceConfig
+
+    @property
+    def posterior_factory(self) -> model_registry.PosteriorFactory:
+        return self.data_config.posterior_factory
+
+
+def process_results(
+    run: Any,
+    experiment_config: ExperimentConfig,
+    param_samples: Any,
+    extra_data: Any,
+    x_path: Any,
+    y_path: Any,
+    condition: Any,
+    result_processor: ResultProcessor | None,
+) -> None:
+    """Delegate experiment results to a result processor if provided."""
+
+    if result_processor is None:
+        return
+
+    result_processor.process(
+        run,
+        experiment_config,
+        param_samples,
+        extra_data,
+        x_path,
+        y_path,
+        condition,
+    )
+
+
+def run_experiment(
+    experiment_name: str,
+    experiment_config: ExperimentConfig,
+    result_processor: ResultProcessor | None = None,
+):
+    """Execute an experiment using the shared harness."""
+
+    config_dict = asdict(experiment_config)
+
+    wandb_run = wandb.init(
+        project=experiment_name,
+        config={
+            **config_dict,
+            "inference_name": experiment_config.inference.name,
+        },
+    )
+
+    target_params = experiment_config.data_config.generative_parameters
+    model = experiment_config.posterior_factory(target_params)
+
+    x_path, y_path, condition = io.get_remote_data(
+        wandb_run, experiment_config.data_config
+    )
+
+    inference = inference_registry.build_inference(experiment_config.inference)
+
+    param_samples, extra_data = inference(
+        model,
+        hyperparameters=None,
+        key=jrandom.key(experiment_config.fit_seed),
+        observation_path=y_path,
+        condition_path=condition,
+        test_samples=experiment_config.test_samples,
+        config=experiment_config.inference.config,
+    )
+
+    process_results(
+        wandb_run,
+        experiment_config,
+        param_samples,
+        extra_data,
+        x_path,
+        y_path,
+        condition,
+        result_processor,
+    )
+
+    wandb_run.finish()
+
+    return (param_samples, extra_data, x_path, y_path)


### PR DESCRIPTION
## Summary
- add `experiments/core.py` to centralize the shared experiment harness logic and forward optional conditioning data
- update the AR(1) and double well comparison experiments to consume the shared helpers and accept the optional condition argument

## Testing
- `pip install .[dev]`
- `pytest` *(fails: BufferedVIConfig signature mismatch in tests)*
- `mypy seqjax` *(fails with existing type errors in seqjax/model/ar.py and seqjax/inference/vi)*

------
https://chatgpt.com/codex/tasks/task_e_68dce713ac988325b414289c2b978b93