### PR TITLE
Add variance-based tuner for particle MCMC

### DIFF
--- a/seqjax/inference/pmcmc/__init__.py
+++ b/seqjax/inference/pmcmc/__init__.py
@@ -1,4 +1,11 @@
 from seqjax.inference.mcmc.metropolis import RandomWalkConfig
 from .pmmh import ParticleMCMCConfig, run_particle_mcmc
+from .tuning import ParticleFilterTuningConfig, tune_particle_filter_variance
 
-__all__ = ["RandomWalkConfig", "ParticleMCMCConfig", "run_particle_mcmc"]
+__all__ = [
+    "RandomWalkConfig",
+    "ParticleMCMCConfig",
+    "ParticleFilterTuningConfig",
+    "tune_particle_filter_variance",
+    "run_particle_mcmc",
+]

--- a/seqjax/inference/pmcmc/tuning.py
+++ b/seqjax/inference/pmcmc/tuning.py
@@ -1,0 +1,167 @@
+"""Utilities for automatically tuning particle filters used in PMCMC."""
+
+from __future__ import annotations
+
+from typing import Callable, List
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+import jaxtyping
+
+import seqjax.model.typing as seqjtyping
+from seqjax.model.base import BayesianSequentialModel
+from seqjax.inference.particlefilter import SMCSampler
+from seqjax import util
+
+
+class ParticleFilterTuningConfig(eqx.Module):
+    """Configuration for :func:`tune_particle_filter_variance`."""
+
+    target_variance: float
+    max_particles: int
+    replications: int
+    diagnostic_samples: int | None = None
+
+
+LogJointEstimator = Callable[
+    [
+        SMCSampler,
+        seqjtyping.Parameters,
+        jaxtyping.PRNGKeyArray,
+    ],
+    jax.Array,
+]
+
+
+def tune_particle_filter_variance[
+    ParametersT: seqjtyping.Parameters,
+    HyperParametersT: seqjtyping.HyperParameters,
+](
+    estimate_log_joint: LogJointEstimator,
+    base_filter: SMCSampler,
+    target_posterior: BayesianSequentialModel,
+    hyperparameters: HyperParametersT,
+    config: ParticleFilterTuningConfig,
+    key: jaxtyping.PRNGKeyArray,
+) -> tuple[SMCSampler, dict[str, list[jax.Array]]]:
+    """Heuristically tune the particle count of an :class:`SMCSampler`.
+
+    The routine evaluates the variance of the log-marginal likelihood estimator
+    for a set of prior-drawn parameter proposals across increasing particle
+    counts until the empirical variance falls below ``config.target_variance``
+    or the ``config.max_particles`` threshold is reached.
+
+    Parameters
+    ----------
+    estimate_log_joint
+        Callable implementing the log joint estimator used by the particle MCMC
+        routine. The helper relies on this to avoid diverging implementations
+        of the marginal likelihood estimator.
+    base_filter
+        The particle filter instance that will be cloned and tuned.
+    target_posterior
+        The sequential model describing the posterior of interest.
+    hyperparameters
+        Hyperparameters used when sampling parameters from the prior.
+    config
+        Tuning hyperparameters controlling the variance threshold, maximum
+        number of particles, number of replications per parameter draw, and the
+        number of diagnostic parameter draws.
+    key
+        PRNG key used for sampling diagnostic parameter proposals and running
+        particle filters.
+
+    Returns
+    -------
+    tuple
+        The tuned :class:`SMCSampler` and a diagnostic log capturing the tested
+        particle counts, per-parameter variances, and raw log-marginal samples
+        produced during tuning.
+    """
+
+    if config.replications <= 0:
+        raise ValueError("replications must be positive")
+
+    parameter_draws = config.diagnostic_samples or 1
+    if parameter_draws <= 0:
+        raise ValueError("diagnostic_samples must be positive when provided")
+
+    key, parameter_key = jrandom.split(key)
+    parameter_keys = jrandom.split(parameter_key, parameter_draws)
+    parameter_samples = jax.vmap(
+        target_posterior.parameter_prior.sample, in_axes=[0, None]
+    )(parameter_keys, hyperparameters)
+
+    parameter_leaves = jax.tree_util.tree_leaves(parameter_samples)
+    if not parameter_leaves:
+        raise ValueError("parameter_samples produced an empty pytree")
+    num_parameter_draws = parameter_leaves[0].shape[0]
+
+    diagnostics: dict[str, list[jax.Array]] = {
+        "particle_counts": [],
+        "per_parameter_variance": [],
+        "log_marginal_samples": [],
+    }
+
+    current_particles = int(base_filter.num_particles)
+    tuned_filter = base_filter
+    continue_search = True
+
+    while continue_search:
+        candidate_particles = min(current_particles, config.max_particles)
+        candidate_filter = eqx.tree_at(
+            lambda pf: pf.num_particles, base_filter, candidate_particles
+        )
+
+        per_parameter_logs: List[jax.Array] = []
+        per_parameter_variances: List[jax.Array] = []
+
+        for draw_ix in range(num_parameter_draws):
+            params = util.index_pytree(parameter_samples, draw_ix)
+            replicate_logs: List[jax.Array] = []
+
+            for _ in range(config.replications):
+                key, subkey = jrandom.split(key)
+                log_joint = estimate_log_joint(candidate_filter, params, subkey)
+                log_prior = target_posterior.parameter_prior.log_prob(
+                    params, hyperparameters
+                )
+                log_marginal = log_joint - log_prior
+                replicate_logs.append(log_marginal)
+
+            log_samples = jnp.stack(replicate_logs)
+            per_parameter_logs.append(log_samples)
+
+            if config.replications > 1:
+                variance = jnp.var(log_samples, ddof=1)
+            else:
+                variance = jnp.zeros_like(log_samples[0])
+            per_parameter_variances.append(variance)
+
+        log_marginal_matrix = jnp.stack(per_parameter_logs)
+        variance_vector = jnp.stack(per_parameter_variances)
+
+        diagnostics["particle_counts"].append(jnp.array(candidate_particles))
+        diagnostics["log_marginal_samples"].append(log_marginal_matrix)
+        diagnostics["per_parameter_variance"].append(variance_vector)
+
+        tuned_filter = candidate_filter
+
+        max_variance = float(jnp.max(variance_vector))
+        if (max_variance <= config.target_variance) or (
+            candidate_particles >= config.max_particles
+        ):
+            continue_search = False
+        else:
+            proposed_particles = candidate_particles * 2
+            if proposed_particles > config.max_particles:
+                proposed_particles = config.max_particles
+            if proposed_particles == candidate_particles:
+                continue_search = False
+            else:
+                current_particles = proposed_particles
+
+    return tuned_filter, diagnostics
+

--- a/tests/inference/test_pmcmc_tuning.py
+++ b/tests/inference/test_pmcmc_tuning.py
@@ -1,0 +1,131 @@
+import jax.numpy as jnp
+import jax.random as jrandom
+
+from seqjax.inference.particlefilter.filter_definitions import BootstrapParticleFilter
+from seqjax.inference.pmcmc.pmmh import (
+    ParticleMCMCConfig,
+    _make_log_joint_estimator,
+    run_particle_mcmc,
+)
+from seqjax.inference.pmcmc.tuning import (
+    ParticleFilterTuningConfig,
+    tune_particle_filter_variance,
+)
+from seqjax.model.ar import AR1Bayesian, ARParameters
+from seqjax.model.simulate import simulate
+from seqjax.model.typing import HyperParameters
+
+
+def _build_test_components(sequence_length: int = 6, num_particles: int = 8):
+    key = jrandom.PRNGKey(0)
+    ref_params = ARParameters(
+        ar=jnp.array(0.5),
+        observation_std=jnp.array(0.3),
+        transition_std=jnp.array(0.2),
+    )
+    posterior = AR1Bayesian(ref_params)
+    _, observations, _, _ = simulate(
+        key,
+        posterior.target,
+        None,
+        ref_params,
+        sequence_length,
+    )
+    base_filter = BootstrapParticleFilter(posterior.target, num_particles=num_particles)
+    return posterior, HyperParameters(), observations, base_filter
+
+
+def test_tune_particle_filter_variance_stops_when_variance_small() -> None:
+    posterior, hyperparameters, observations, base_filter = _build_test_components()
+    estimator = _make_log_joint_estimator(
+        posterior,
+        hyperparameters,
+        observations,
+        None,
+    )
+    tuning_config = ParticleFilterTuningConfig(
+        target_variance=1e6,
+        max_particles=32,
+        replications=3,
+        diagnostic_samples=2,
+    )
+    key = jrandom.PRNGKey(1)
+    tuned_filter, diagnostics = tune_particle_filter_variance(
+        estimator,
+        base_filter,
+        posterior,
+        hyperparameters,
+        tuning_config,
+        key,
+    )
+
+    assert tuned_filter.num_particles == base_filter.num_particles
+    assert len(diagnostics["particle_counts"]) == 1
+    final_variance = float(jnp.max(diagnostics["per_parameter_variance"][-1]))
+    assert final_variance <= tuning_config.target_variance
+
+
+def test_tune_particle_filter_variance_hits_particle_cap() -> None:
+    posterior, hyperparameters, observations, base_filter = _build_test_components(
+        num_particles=4
+    )
+    estimator = _make_log_joint_estimator(
+        posterior,
+        hyperparameters,
+        observations,
+        None,
+    )
+    tuning_config = ParticleFilterTuningConfig(
+        target_variance=1e-6,
+        max_particles=32,
+        replications=4,
+        diagnostic_samples=2,
+    )
+    key = jrandom.PRNGKey(2)
+    tuned_filter, diagnostics = tune_particle_filter_variance(
+        estimator,
+        base_filter,
+        posterior,
+        hyperparameters,
+        tuning_config,
+        key,
+    )
+
+    assert tuned_filter.num_particles == tuning_config.max_particles
+    assert int(diagnostics["particle_counts"][-1]) == tuning_config.max_particles
+    assert len(diagnostics["particle_counts"]) > 1
+
+
+def test_run_particle_mcmc_reports_tuning_diagnostics() -> None:
+    posterior, hyperparameters, observations, base_filter = _build_test_components(
+        num_particles=4
+    )
+    tuning_config = ParticleFilterTuningConfig(
+        target_variance=1e-6,
+        max_particles=32,
+        replications=4,
+        diagnostic_samples=2,
+    )
+    config = ParticleMCMCConfig(
+        particle_filter=base_filter,
+        initial_parameter_guesses=3,
+        tuning=tuning_config,
+    )
+    key = jrandom.PRNGKey(3)
+    samples, diagnostics = run_particle_mcmc(
+        posterior,
+        hyperparameters,
+        key,
+        observations,
+        None,
+        test_samples=4,
+        config=config,
+    )
+
+    assert len(diagnostics) == 2
+    tuning_log = diagnostics[1]
+    assert int(tuning_log["particle_counts"][-1]) == tuning_config.max_particles
+    assert tuning_log["log_marginal_samples"][-1].shape[0] == (
+        tuning_config.diagnostic_samples or 1
+    )
+

--- a/tests/inference/test_registry_inference.py
+++ b/tests/inference/test_registry_inference.py
@@ -56,8 +56,7 @@ INFERENCE_TEST_SETUPS: dict[str, tuple[object, int]] = {
     ),
     "buffer-vi": (
         vi.BufferedVIConfig(
-            learning_rate=1e-2,
-            opt_steps=2,
+            optimization=vi.run.AdamOpt(lr=1e-2, total_steps=2),
             buffer_length=2,
             batch_length=4,
             parameter_field_bijections={"ar": "sigmoid"},
@@ -72,11 +71,8 @@ INFERENCE_TEST_SETUPS: dict[str, tuple[object, int]] = {
     ),
     "full-vi": (
         vi.FullVIConfig(
-            learning_rate=1e-2,
-            opt_steps=2,
+            optimization=vi.run.AdamOpt(lr=1e-2, total_steps=2),
             parameter_field_bijections={"ar": "sigmoid"},
-            prev_window=1,
-            post_window=1,
             observations_per_step=1,
             samples_per_context=1,
         ),


### PR DESCRIPTION
## Summary
- add a variance-based particle-filter tuning helper and configuration module for PMCMC
- extend `ParticleMCMCConfig` to support optional tuning and thread the tuned filter/diagnostics through PMMH
- add PMCMC tuning regression coverage and update registry tests for the current VI configuration API

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_68dd108fb4ec8325b642c5fbab9f3bb5