### PR TITLE
Add Masked Autoregressive VI parameter option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "jax>=0.5.2",
     "equinox>=0.12.1",
     "jaxtyping>=0.2.38",
+    "flowjax>=17.2.0",
     "graphviz",
     "blackjax",
     "distrax",


### PR DESCRIPTION
## Summary
- add a flowjax-based `MaskedAutoregressiveFlow` unconditional approximation and factory for VI parameters
- extend VI configuration to choose between mean-field and masked autoregressive parameter approximations
- wire the new parameter approximation through the VI runners and declare the flowjax dependency

## Testing
- `pip install .[dev]`
- `pytest`
- `mypy seqjax`


------
https://chatgpt.com/codex/tasks/task_e_68df88822db483258be3e25d071b194a