### PR TITLE
Support Slurm job `mode` (run | latent-fit) with validation and CLI test coverage

### DIFF
--- a/seqjax/cli/slurm_jobs.py
+++ b/seqjax/cli/slurm_jobs.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import importlib.util
 import itertools
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
+
+SlurmMode = Literal["run", "latent-fit"]
 
 
 class SharedPlan(TypedDict, total=False):
+    mode: SlurmMode
     model: str
     parameters: str
     sequence_length: int
@@ -24,6 +27,14 @@ class SharedPlan(TypedDict, total=False):
     data_seed_repeats: int
     base_fit_seed: int
     base_data_seed: int
+
+
+def _parse_mode(raw_mode: object, *, location: str) -> SlurmMode:
+    if raw_mode == "run" or raw_mode == "latent-fit":
+        return raw_mode
+    raise ValueError(
+        f"Invalid mode {raw_mode!r} in {location}; expected one of: 'run', 'latent-fit'"
+    )
 
 
 def _quote(token: str) -> str:
@@ -82,6 +93,7 @@ def _validate_code_tokens(code_tokens: list[str]) -> None:
 
 def _render_script(
     *,
+    mode: SlurmMode,
     experiment_name: str,
     study_name: str,
     output_pattern: str,
@@ -94,7 +106,7 @@ def _render_script(
     sequence_length: int,
     num_sequences: int,
     base_data_seed: int,
-    inference: str,
+    inference: str | None,
     fixed_codes: list[str],
     combination: tuple[str, ...],
     fit_seed_repeats: int,
@@ -102,6 +114,13 @@ def _render_script(
     base_fit_seed: int,
     test_samples: int | None,
 ) -> str:
+    if mode == "run" and inference is None:
+        raise ValueError("mode='run' requires shared.inference to be set")
+    if mode == "latent-fit" and inference is not None:
+        raise ValueError("mode='latent-fit' does not accept shared.inference")
+    if mode == "latent-fit" and test_samples is not None:
+        raise ValueError("mode='latent-fit' does not accept shared.test_samples")
+
     total_repeats = fit_seed_repeats * data_seed_repeats
     if total_repeats <= 0:
         raise ValueError("fit_seed_repeats * data_seed_repeats must be positive")
@@ -133,18 +152,20 @@ def _render_script(
 
     lines.extend(
         [
-            "CMD=(python -m seqjax.cli run",
+            f"CMD=(python -m seqjax.cli {mode}",
             f"  --model {model}",
             f"  --parameters {_quote(generative_parameters)}",
             f"  --sequence-length {sequence_length}",
             f"  --num-sequences {num_sequences}",
             '  --data-seed "$DATA_SEED"',
             '  --fit-seed "$FIT_SEED"',
-            f"  --inference {inference}",
         ]
     )
 
-    if test_samples is not None:
+    if mode == "run":
+        lines.append(f"  --inference {inference}")
+
+    if mode == "run" and test_samples is not None:
         lines.append(f"  --test-samples {test_samples}")
 
     for token in fixed_codes:
@@ -207,6 +228,7 @@ def generate_slurm_jobs(
     logs_dir = experiment_dir / "logs"
 
     shared = cast(SharedPlan, dict(plan.get("shared", {})))
+    shared_mode = _parse_mode(shared.get("mode", "run"), location="PLAN.shared.mode")
     generative_parameters = str(shared.get("parameters", "base"))
     if not generative_parameters:
         raise ValueError("shared.parameters must be a non-empty string when provided")
@@ -222,6 +244,7 @@ def generate_slurm_jobs(
     for study in plan["studies"]:
         study_name = study["name"]
         study_dir_name = str(study_name).replace(" ", "-")
+        mode = _parse_mode(study.get("mode", shared_mode), location=f"study {study_name!r}.mode")
 
         fixed_codes = list(shared.get("fixed_codes", [])) + list(study.get("fixed_codes", []))
         axes = study.get("axes", {})
@@ -254,6 +277,7 @@ def generate_slurm_jobs(
                 ) from exc
 
             script_text = _render_script(
+                mode=mode,
                 experiment_name=experiment_name,
                 study_name=str(study.get("job_name", study_dir_name)),
                 output_pattern=output_pattern,
@@ -266,7 +290,7 @@ def generate_slurm_jobs(
                 sequence_length=int(shared["sequence_length"]),
                 num_sequences=int(shared.get("num_sequences", 1)),
                 base_data_seed=base_data_seed,
-                inference=str(shared["inference"]),
+                inference=cast(str | None, shared.get("inference")),
                 fixed_codes=fixed_codes,
                 combination=combination,
                 fit_seed_repeats=fit_seed_repeats,

--- a/tests/test_slurm_jobs.py
+++ b/tests/test_slurm_jobs.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from _pytest.capture import CaptureFixture
+from typer.testing import CliRunner
 
+from seqjax.cli.cli import app
 from seqjax.cli import slurm_jobs
 
 
@@ -14,7 +17,7 @@ PLAN = {
     "experiment_name": "demo-experiment",
     "output_root": "jobs",
     "shared": {
-        "model": "aicher_stochastic_vol",
+        "model": "ar-full",
         "inference": "buffer-vi",
         "sequence_length": 25,
         "wall_time": "00:30:00",
@@ -39,6 +42,39 @@ PLAN = {
 """,
         encoding="utf-8",
     )
+
+
+def _extract_cli_argv(script_text: str) -> list[str]:
+    lines = script_text.splitlines()
+    cmd_start_ix = next(ix for ix, line in enumerate(lines) if line.startswith("CMD=("))
+    cmd_end_ix = next(ix for ix in range(cmd_start_ix + 1, len(lines)) if lines[ix] == ")")
+    cmd_lines = lines[cmd_start_ix:cmd_end_ix]
+    cmd_lines[0] = cmd_lines[0].removeprefix("CMD=(")
+    command_tokens = shlex.split(" ".join(line.strip() for line in cmd_lines))
+    assert command_tokens[:3] == ["python", "-m", "seqjax.cli"]
+
+    experiment_line = lines[cmd_end_ix + 1]
+    assert experiment_line.startswith("CMD+=(") and experiment_line.endswith(")")
+    experiment_tokens = shlex.split(experiment_line[len("CMD+=(") : -1])
+    argv = [*command_tokens[3:], *experiment_tokens]
+    return [
+        "101" if token == "$DATA_SEED" else "7" if token == "$FIT_SEED" else token
+        for token in argv
+    ]
+
+
+def _drop_code_args(argv: list[str]) -> list[str]:
+    filtered: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "--code":
+            skip_next = True
+            continue
+        filtered.append(token)
+    return filtered
 
 
 def test_generate_slurm_jobs_one_script_per_configuration(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
@@ -68,6 +104,83 @@ def test_generate_slurm_jobs_one_script_per_configuration(tmp_path: Path, capsys
     output = capsys.readouterr().out
     assert "Total requested wall time across generated jobs: 03:00:00" in output
     assert "gpu-hours: 3.00" in output
+
+    runner = CliRunner()
+    parsed = runner.invoke(app, [*(_drop_code_args(_extract_cli_argv(script))), "--dry-run"])
+    assert parsed.exit_code == 0, parsed.stdout
+
+
+def test_generate_slurm_jobs_latent_fit_mode_script_parses_cli(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.py"
+    plan_file.write_text(
+        """
+PLAN = {
+    "experiment_name": "latent-demo",
+    "shared": {
+        "mode": "latent-fit",
+        "model": "ar-full",
+        "parameters": "base",
+        "sequence_length": 25,
+        "num_sequences": 1,
+        "fit_seed_repeats": 1,
+        "data_seed_repeats": 1,
+    },
+    "studies": [
+        {
+            "name": "latent_study",
+            "axes": {"a": [["OPT.ADAM", "OPT.ADAM.LR-1e-2"], ["OPT.ADAM", "OPT.ADAM.LR-5e-3"]]},
+        }
+    ],
+}
+""",
+        encoding="utf-8",
+    )
+
+    outputs = slurm_jobs.generate_slurm_jobs(
+        plan_file=str(plan_file),
+        output_root_override=str(tmp_path / "out"),
+        dry_run=False,
+    )
+
+    script = outputs[0].read_text(encoding="utf-8")
+    assert "CMD=(python -m seqjax.cli latent-fit" in script
+    assert "  --inference " not in script
+    assert "  --test-samples " not in script
+
+    runner = CliRunner()
+    parsed = runner.invoke(app, [*(_extract_cli_argv(script)), "--dry-run"])
+    assert parsed.exit_code == 0, parsed.stdout
+
+
+def test_generate_slurm_jobs_latent_fit_rejects_inference(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.py"
+    plan_file.write_text(
+        """
+PLAN = {
+    "experiment_name": "latent-demo",
+    "shared": {
+        "mode": "latent-fit",
+        "model": "aicher_stochastic_vol",
+        "parameters": "base",
+        "inference": "buffer-vi",
+        "sequence_length": 25,
+    },
+    "studies": [{"name": "latent_study", "axes": {"a": [["OPT.ADAM"]]}}],
+}
+""",
+        encoding="utf-8",
+    )
+
+    try:
+        slurm_jobs.generate_slurm_jobs(
+            plan_file=str(plan_file),
+            output_root_override=str(tmp_path / "out"),
+            dry_run=True,
+        )
+    except ValueError as exc:
+        assert "does not accept shared.inference" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for latent-fit plan with shared.inference")
 
 
 def test_generate_slurm_jobs_study_overrides_repeats(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Introduce an explicit per-plan and per-study `mode` to allow generating different Slurm command invocations (e.g. `run` vs `latent-fit`) and to validate incompatible options.

### Description

- Add `SlurmMode = Literal["run", "latent-fit"]` and include `mode` in the shared plan type and per-study overrides.
- Implement `_parse_mode` to validate mode values and apply it to shared and study-level mode selection.
- Update `_render_script` to accept `mode` and enforce that `mode='run'` requires `shared.inference` and may use `test_samples`, while `mode='latent-fit'` must not include `inference` or `test_samples`, and switch the generated CLI subcommand accordingly.
- Adjust command assembly to use the selected `mode` instead of always using `run` and cast `inference` to optional when forwarding shared values.
- Expand `tests/test_slurm_jobs.py` to parse the generated script `CMD` using `shlex`, exercise the CLI via `CliRunner`, and add tests that assert proper behavior and erroring for `latent-fit` plans.

### Testing

- Ran the Slurm job tests in `tests/test_slurm_jobs.py` including `test_generate_slurm_jobs_one_script_per_configuration`, `test_generate_slurm_jobs_latent_fit_mode_script_parses_cli`, and `test_generate_slurm_jobs_latent_fit_rejects_inference`, and they all passed.
- Executed the CLI invocation checks via `typer.testing.CliRunner` for generated scripts and the invocations returned exit code `0` as expected.
- Existing job-generation assertions (array sizing, seed expressions, code arguments, and total wall-time/gpu-hours) were preserved and validated by the test suite successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7ac7164c83259078d94bf799cf1d)